### PR TITLE
SQLiteデータベース層の完全実装

### DIFF
--- a/lib/core/database/database_helper.dart
+++ b/lib/core/database/database_helper.dart
@@ -75,7 +75,31 @@ class DatabaseHelper {
   }
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
-    // 将来のバージョンアップ時に使用
+    for (int version = oldVersion + 1; version <= newVersion; version++) {
+      switch (version) {
+        case 2:
+          await _upgradeToVersion2(db);
+          break;
+        case 3:
+          await _upgradeToVersion3(db);
+          break;
+        default:
+          throw UnsupportedError('Unsupported database version: $version');
+      }
+    }
+  }
+
+  Future<void> _upgradeToVersion2(Database db) async {
+    // 例: storesテーブルにratingカラムを追加
+    await db.execute('ALTER TABLE stores ADD COLUMN rating REAL DEFAULT 0.0');
+    
+    // 新しいインデックスを追加
+    await db.execute('CREATE INDEX idx_stores_rating ON stores (rating)');
+  }
+
+  Future<void> _upgradeToVersion3(Database db) async {
+    // 例: 将来の拡張用
+    // await db.execute('ALTER TABLE stores ADD COLUMN phone TEXT');
   }
 
   Future<void> close() async {

--- a/lib/core/database/database_helper.dart
+++ b/lib/core/database/database_helper.dart
@@ -1,0 +1,86 @@
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+import '../constants/app_constants.dart';
+
+class DatabaseHelper {
+  static final DatabaseHelper _instance = DatabaseHelper._internal();
+  static Database? _database;
+
+  DatabaseHelper._internal();
+
+  factory DatabaseHelper() => _instance;
+
+  Future<Database> get database async {
+    _database ??= await _initDatabase();
+    return _database!;
+  }
+
+  Future<Database> _initDatabase() async {
+    final databasesPath = await getDatabasesPath();
+    final path = join(databasesPath, AppConstants.databaseName);
+
+    return await openDatabase(
+      path,
+      version: AppConstants.databaseVersion,
+      onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
+    );
+  }
+
+  Future<void> _onCreate(Database db, int version) async {
+    // Storesテーブル
+    await db.execute('''
+      CREATE TABLE stores (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        address TEXT NOT NULL,
+        lat REAL NOT NULL,
+        lng REAL NOT NULL,
+        status TEXT,
+        memo TEXT,
+        created_at TEXT NOT NULL
+      )
+    ''');
+
+    // VisitRecordsテーブル
+    await db.execute('''
+      CREATE TABLE visit_records (
+        id TEXT PRIMARY KEY,
+        store_id TEXT NOT NULL,
+        visited_at TEXT NOT NULL,
+        menu TEXT NOT NULL,
+        memo TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (store_id) REFERENCES stores (id)
+      )
+    ''');
+
+    // Photosテーブル
+    await db.execute('''
+      CREATE TABLE photos (
+        id TEXT PRIMARY KEY,
+        store_id TEXT NOT NULL,
+        visit_id TEXT,
+        file_path TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (store_id) REFERENCES stores (id),
+        FOREIGN KEY (visit_id) REFERENCES visit_records (id)
+      )
+    ''');
+
+    // インデックス作成
+    await db.execute('CREATE INDEX idx_stores_status ON stores (status)');
+    await db.execute('CREATE INDEX idx_visit_records_store_id ON visit_records (store_id)');
+    await db.execute('CREATE INDEX idx_photos_store_id ON photos (store_id)');
+  }
+
+  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    // 将来のバージョンアップ時に使用
+  }
+
+  Future<void> close() async {
+    final db = await database;
+    await db.close();
+    _database = null;
+  }
+}

--- a/lib/data/datasources/photo_local_datasource.dart
+++ b/lib/data/datasources/photo_local_datasource.dart
@@ -1,0 +1,91 @@
+import 'package:sqflite/sqflite.dart';
+import '../../core/database/database_helper.dart';
+import '../models/photo_model.dart';
+
+class PhotoLocalDatasource {
+  final DatabaseHelper _databaseHelper;
+
+  PhotoLocalDatasource(this._databaseHelper);
+
+  Future<List<PhotoModel>> getAllPhotos() async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'photos',
+      orderBy: 'created_at DESC',
+    );
+
+    return List.generate(maps.length, (i) {
+      return PhotoModel.fromMap(maps[i]);
+    });
+  }
+
+  Future<List<PhotoModel>> getPhotosByStoreId(String storeId) async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'photos',
+      where: 'store_id = ?',
+      whereArgs: [storeId],
+      orderBy: 'created_at DESC',
+    );
+
+    return List.generate(maps.length, (i) {
+      return PhotoModel.fromMap(maps[i]);
+    });
+  }
+
+  Future<List<PhotoModel>> getPhotosByVisitId(String visitId) async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'photos',
+      where: 'visit_id = ?',
+      whereArgs: [visitId],
+      orderBy: 'created_at DESC',
+    );
+
+    return List.generate(maps.length, (i) {
+      return PhotoModel.fromMap(maps[i]);
+    });
+  }
+
+  Future<PhotoModel?> getPhotoById(String id) async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'photos',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+
+    if (maps.isNotEmpty) {
+      return PhotoModel.fromMap(maps.first);
+    }
+    return null;
+  }
+
+  Future<void> insertPhoto(PhotoModel photo) async {
+    final db = await _databaseHelper.database;
+    await db.insert(
+      'photos',
+      photo.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> updatePhoto(PhotoModel photo) async {
+    final db = await _databaseHelper.database;
+    await db.update(
+      'photos',
+      photo.toMap(),
+      where: 'id = ?',
+      whereArgs: [photo.id],
+    );
+  }
+
+  Future<void> deletePhoto(String id) async {
+    final db = await _databaseHelper.database;
+    await db.delete(
+      'photos',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+}

--- a/lib/data/datasources/store_local_datasource.dart
+++ b/lib/data/datasources/store_local_datasource.dart
@@ -1,0 +1,92 @@
+import 'package:sqflite/sqflite.dart';
+import '../../core/database/database_helper.dart';
+import '../models/store_model.dart';
+import '../../domain/entities/store.dart';
+
+class StoreLocalDatasource {
+  final DatabaseHelper _databaseHelper;
+
+  StoreLocalDatasource(this._databaseHelper);
+
+  Future<List<StoreModel>> getAllStores() async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'stores',
+      orderBy: 'created_at DESC',
+    );
+
+    return List.generate(maps.length, (i) {
+      return StoreModel.fromMap(maps[i]);
+    });
+  }
+
+  Future<List<StoreModel>> getStoresByStatus(StoreStatus status) async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'stores',
+      where: 'status = ?',
+      whereArgs: [status.value],
+      orderBy: 'created_at DESC',
+    );
+
+    return List.generate(maps.length, (i) {
+      return StoreModel.fromMap(maps[i]);
+    });
+  }
+
+  Future<StoreModel?> getStoreById(String id) async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'stores',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+
+    if (maps.isNotEmpty) {
+      return StoreModel.fromMap(maps.first);
+    }
+    return null;
+  }
+
+  Future<void> insertStore(StoreModel store) async {
+    final db = await _databaseHelper.database;
+    await db.insert(
+      'stores',
+      store.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> updateStore(StoreModel store) async {
+    final db = await _databaseHelper.database;
+    await db.update(
+      'stores',
+      store.toMap(),
+      where: 'id = ?',
+      whereArgs: [store.id],
+    );
+  }
+
+  Future<void> deleteStore(String id) async {
+    final db = await _databaseHelper.database;
+    await db.delete(
+      'stores',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<List<StoreModel>> searchStores(String query) async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'stores',
+      where: 'name LIKE ? OR address LIKE ?',
+      whereArgs: ['%$query%', '%$query%'],
+      orderBy: 'created_at DESC',
+    );
+
+    return List.generate(maps.length, (i) {
+      return StoreModel.fromMap(maps[i]);
+    });
+  }
+}

--- a/lib/data/datasources/store_local_datasource.dart
+++ b/lib/data/datasources/store_local_datasource.dart
@@ -9,84 +9,148 @@ class StoreLocalDatasource {
   StoreLocalDatasource(this._databaseHelper);
 
   Future<List<StoreModel>> getAllStores() async {
-    final db = await _databaseHelper.database;
-    final List<Map<String, dynamic>> maps = await db.query(
-      'stores',
-      orderBy: 'created_at DESC',
-    );
+    try {
+      final db = await _databaseHelper.database;
+      final List<Map<String, dynamic>> maps = await db.query(
+        'stores',
+        orderBy: 'created_at DESC',
+      );
 
-    return List.generate(maps.length, (i) {
-      return StoreModel.fromMap(maps[i]);
-    });
+      return List.generate(maps.length, (i) {
+        return StoreModel.fromMap(maps[i]);
+      });
+    } on DatabaseException catch (e) {
+      throw DatabaseException('Failed to fetch stores: ${e.toString()}');
+    } catch (e) {
+      throw Exception('Unexpected error: ${e.toString()}');
+    }
+  }
+
+  Future<List<StoreModel>> getStoresPaginated({
+    int page = 0,
+    int pageSize = 20,
+  }) async {
+    try {
+      final offset = page * pageSize;
+      final db = await _databaseHelper.database;
+      final List<Map<String, dynamic>> maps = await db.query(
+        'stores',
+        orderBy: 'created_at DESC',
+        limit: pageSize,
+        offset: offset,
+      );
+
+      return maps.map((map) => StoreModel.fromMap(map)).toList();
+    } on DatabaseException catch (e) {
+      throw DatabaseException('Failed to fetch paginated stores: ${e.toString()}');
+    } catch (e) {
+      throw Exception('Unexpected error: ${e.toString()}');
+    }
   }
 
   Future<List<StoreModel>> getStoresByStatus(StoreStatus status) async {
-    final db = await _databaseHelper.database;
-    final List<Map<String, dynamic>> maps = await db.query(
-      'stores',
-      where: 'status = ?',
-      whereArgs: [status.value],
-      orderBy: 'created_at DESC',
-    );
+    try {
+      final db = await _databaseHelper.database;
+      final List<Map<String, dynamic>> maps = await db.query(
+        'stores',
+        where: 'status = ?',
+        whereArgs: [status.value],
+        orderBy: 'created_at DESC',
+      );
 
-    return List.generate(maps.length, (i) {
-      return StoreModel.fromMap(maps[i]);
-    });
+      return List.generate(maps.length, (i) {
+        return StoreModel.fromMap(maps[i]);
+      });
+    } on DatabaseException catch (e) {
+      throw DatabaseException('Failed to fetch stores by status: ${e.toString()}');
+    } catch (e) {
+      throw Exception('Unexpected error: ${e.toString()}');
+    }
   }
 
   Future<StoreModel?> getStoreById(String id) async {
-    final db = await _databaseHelper.database;
-    final List<Map<String, dynamic>> maps = await db.query(
-      'stores',
-      where: 'id = ?',
-      whereArgs: [id],
-    );
+    try {
+      final db = await _databaseHelper.database;
+      final List<Map<String, dynamic>> maps = await db.query(
+        'stores',
+        where: 'id = ?',
+        whereArgs: [id],
+      );
 
-    if (maps.isNotEmpty) {
-      return StoreModel.fromMap(maps.first);
+      if (maps.isNotEmpty) {
+        return StoreModel.fromMap(maps.first);
+      }
+      return null;
+    } on DatabaseException catch (e) {
+      throw DatabaseException('Failed to fetch store by id: ${e.toString()}');
+    } catch (e) {
+      throw Exception('Unexpected error: ${e.toString()}');
     }
-    return null;
   }
 
   Future<void> insertStore(StoreModel store) async {
-    final db = await _databaseHelper.database;
-    await db.insert(
-      'stores',
-      store.toMap(),
-      conflictAlgorithm: ConflictAlgorithm.replace,
-    );
+    try {
+      final db = await _databaseHelper.database;
+      await db.insert(
+        'stores',
+        store.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    } on DatabaseException catch (e) {
+      throw DatabaseException('Failed to insert store: ${e.toString()}');
+    } catch (e) {
+      throw Exception('Unexpected error: ${e.toString()}');
+    }
   }
 
   Future<void> updateStore(StoreModel store) async {
-    final db = await _databaseHelper.database;
-    await db.update(
-      'stores',
-      store.toMap(),
-      where: 'id = ?',
-      whereArgs: [store.id],
-    );
+    try {
+      final db = await _databaseHelper.database;
+      await db.update(
+        'stores',
+        store.toMap(),
+        where: 'id = ?',
+        whereArgs: [store.id],
+      );
+    } on DatabaseException catch (e) {
+      throw DatabaseException('Failed to update store: ${e.toString()}');
+    } catch (e) {
+      throw Exception('Unexpected error: ${e.toString()}');
+    }
   }
 
   Future<void> deleteStore(String id) async {
-    final db = await _databaseHelper.database;
-    await db.delete(
-      'stores',
-      where: 'id = ?',
-      whereArgs: [id],
-    );
+    try {
+      final db = await _databaseHelper.database;
+      await db.delete(
+        'stores',
+        where: 'id = ?',
+        whereArgs: [id],
+      );
+    } on DatabaseException catch (e) {
+      throw DatabaseException('Failed to delete store: ${e.toString()}');
+    } catch (e) {
+      throw Exception('Unexpected error: ${e.toString()}');
+    }
   }
 
   Future<List<StoreModel>> searchStores(String query) async {
-    final db = await _databaseHelper.database;
-    final List<Map<String, dynamic>> maps = await db.query(
-      'stores',
-      where: 'name LIKE ? OR address LIKE ?',
-      whereArgs: ['%$query%', '%$query%'],
-      orderBy: 'created_at DESC',
-    );
+    try {
+      final db = await _databaseHelper.database;
+      final List<Map<String, dynamic>> maps = await db.query(
+        'stores',
+        where: 'name LIKE ? OR address LIKE ?',
+        whereArgs: ['%$query%', '%$query%'],
+        orderBy: 'created_at DESC',
+      );
 
-    return List.generate(maps.length, (i) {
-      return StoreModel.fromMap(maps[i]);
-    });
+      return List.generate(maps.length, (i) {
+        return StoreModel.fromMap(maps[i]);
+      });
+    } on DatabaseException catch (e) {
+      throw DatabaseException('Failed to search stores: ${e.toString()}');
+    } catch (e) {
+      throw Exception('Unexpected error: ${e.toString()}');
+    }
   }
 }

--- a/lib/data/datasources/visit_record_local_datasource.dart
+++ b/lib/data/datasources/visit_record_local_datasource.dart
@@ -1,0 +1,77 @@
+import 'package:sqflite/sqflite.dart';
+import '../../core/database/database_helper.dart';
+import '../models/visit_record_model.dart';
+
+class VisitRecordLocalDatasource {
+  final DatabaseHelper _databaseHelper;
+
+  VisitRecordLocalDatasource(this._databaseHelper);
+
+  Future<List<VisitRecordModel>> getAllVisitRecords() async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'visit_records',
+      orderBy: 'visited_at DESC',
+    );
+
+    return List.generate(maps.length, (i) {
+      return VisitRecordModel.fromMap(maps[i]);
+    });
+  }
+
+  Future<List<VisitRecordModel>> getVisitRecordsByStoreId(String storeId) async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'visit_records',
+      where: 'store_id = ?',
+      whereArgs: [storeId],
+      orderBy: 'visited_at DESC',
+    );
+
+    return List.generate(maps.length, (i) {
+      return VisitRecordModel.fromMap(maps[i]);
+    });
+  }
+
+  Future<VisitRecordModel?> getVisitRecordById(String id) async {
+    final db = await _databaseHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'visit_records',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+
+    if (maps.isNotEmpty) {
+      return VisitRecordModel.fromMap(maps.first);
+    }
+    return null;
+  }
+
+  Future<void> insertVisitRecord(VisitRecordModel visitRecord) async {
+    final db = await _databaseHelper.database;
+    await db.insert(
+      'visit_records',
+      visitRecord.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> updateVisitRecord(VisitRecordModel visitRecord) async {
+    final db = await _databaseHelper.database;
+    await db.update(
+      'visit_records',
+      visitRecord.toMap(),
+      where: 'id = ?',
+      whereArgs: [visitRecord.id],
+    );
+  }
+
+  Future<void> deleteVisitRecord(String id) async {
+    final db = await _databaseHelper.database;
+    await db.delete(
+      'visit_records',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+}

--- a/lib/data/models/photo_model.dart
+++ b/lib/data/models/photo_model.dart
@@ -1,0 +1,57 @@
+import '../../domain/entities/photo.dart';
+
+class PhotoModel extends Photo {
+  const PhotoModel({
+    required super.id,
+    required super.storeId,
+    super.visitId,
+    required super.filePath,
+    required super.createdAt,
+  });
+
+  factory PhotoModel.fromMap(Map<String, dynamic> map) {
+    return PhotoModel(
+      id: map['id'] as String,
+      storeId: map['store_id'] as String,
+      visitId: map['visit_id'] as String?,
+      filePath: map['file_path'] as String,
+      createdAt: DateTime.parse(map['created_at'] as String),
+    );
+  }
+
+  factory PhotoModel.fromEntity(Photo photo) {
+    return PhotoModel(
+      id: photo.id,
+      storeId: photo.storeId,
+      visitId: photo.visitId,
+      filePath: photo.filePath,
+      createdAt: photo.createdAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'store_id': storeId,
+      'visit_id': visitId,
+      'file_path': filePath,
+      'created_at': createdAt.toIso8601String(),
+    };
+  }
+
+  PhotoModel copyWith({
+    String? id,
+    String? storeId,
+    String? visitId,
+    String? filePath,
+    DateTime? createdAt,
+  }) {
+    return PhotoModel(
+      id: id ?? this.id,
+      storeId: storeId ?? this.storeId,
+      visitId: visitId ?? this.visitId,
+      filePath: filePath ?? this.filePath,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/data/models/store_model.dart
+++ b/lib/data/models/store_model.dart
@@ -1,0 +1,80 @@
+import '../../domain/entities/store.dart';
+
+class StoreModel extends Store {
+  const StoreModel({
+    required super.id,
+    required super.name,
+    required super.address,
+    required super.lat,
+    required super.lng,
+    super.status,
+    super.memo,
+    required super.createdAt,
+  });
+
+  factory StoreModel.fromMap(Map<String, dynamic> map) {
+    return StoreModel(
+      id: map['id'] as String,
+      name: map['name'] as String,
+      address: map['address'] as String,
+      lat: (map['lat'] as num).toDouble(),
+      lng: (map['lng'] as num).toDouble(),
+      status: map['status'] != null 
+        ? StoreStatus.values.firstWhere(
+            (e) => e.value == map['status'],
+            orElse: () => StoreStatus.wantToGo,
+          )
+        : null,
+      memo: map['memo'] as String?,
+      createdAt: DateTime.parse(map['created_at'] as String),
+    );
+  }
+
+  factory StoreModel.fromEntity(Store store) {
+    return StoreModel(
+      id: store.id,
+      name: store.name,
+      address: store.address,
+      lat: store.lat,
+      lng: store.lng,
+      status: store.status,
+      memo: store.memo,
+      createdAt: store.createdAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'address': address,
+      'lat': lat,
+      'lng': lng,
+      'status': status?.value,
+      'memo': memo,
+      'created_at': createdAt.toIso8601String(),
+    };
+  }
+
+  StoreModel copyWith({
+    String? id,
+    String? name,
+    String? address,
+    double? lat,
+    double? lng,
+    StoreStatus? status,
+    String? memo,
+    DateTime? createdAt,
+  }) {
+    return StoreModel(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      address: address ?? this.address,
+      lat: lat ?? this.lat,
+      lng: lng ?? this.lng,
+      status: status ?? this.status,
+      memo: memo ?? this.memo,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/data/models/visit_record_model.dart
+++ b/lib/data/models/visit_record_model.dart
@@ -1,0 +1,63 @@
+import '../../domain/entities/visit_record.dart';
+
+class VisitRecordModel extends VisitRecord {
+  const VisitRecordModel({
+    required super.id,
+    required super.storeId,
+    required super.visitedAt,
+    required super.menu,
+    required super.memo,
+    required super.createdAt,
+  });
+
+  factory VisitRecordModel.fromMap(Map<String, dynamic> map) {
+    return VisitRecordModel(
+      id: map['id'] as String,
+      storeId: map['store_id'] as String,
+      visitedAt: DateTime.parse(map['visited_at'] as String),
+      menu: map['menu'] as String,
+      memo: map['memo'] as String,
+      createdAt: DateTime.parse(map['created_at'] as String),
+    );
+  }
+
+  factory VisitRecordModel.fromEntity(VisitRecord visitRecord) {
+    return VisitRecordModel(
+      id: visitRecord.id,
+      storeId: visitRecord.storeId,
+      visitedAt: visitRecord.visitedAt,
+      menu: visitRecord.menu,
+      memo: visitRecord.memo,
+      createdAt: visitRecord.createdAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'store_id': storeId,
+      'visited_at': visitedAt.toIso8601String(),
+      'menu': menu,
+      'memo': memo,
+      'created_at': createdAt.toIso8601String(),
+    };
+  }
+
+  VisitRecordModel copyWith({
+    String? id,
+    String? storeId,
+    DateTime? visitedAt,
+    String? menu,
+    String? memo,
+    DateTime? createdAt,
+  }) {
+    return VisitRecordModel(
+      id: id ?? this.id,
+      storeId: storeId ?? this.storeId,
+      visitedAt: visitedAt ?? this.visitedAt,
+      menu: menu ?? this.menu,
+      memo: memo ?? this.memo,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/data/repositories/photo_repository_impl.dart
+++ b/lib/data/repositories/photo_repository_impl.dart
@@ -1,0 +1,51 @@
+import '../../domain/entities/photo.dart';
+import '../../domain/repositories/photo_repository.dart';
+import '../datasources/photo_local_datasource.dart';
+import '../models/photo_model.dart';
+
+class PhotoRepositoryImpl implements PhotoRepository {
+  final PhotoLocalDatasource _localDatasource;
+
+  PhotoRepositoryImpl(this._localDatasource);
+
+  @override
+  Future<List<Photo>> getAllPhotos() async {
+    final photoModels = await _localDatasource.getAllPhotos();
+    return photoModels.cast<Photo>();
+  }
+
+  @override
+  Future<List<Photo>> getPhotosByStoreId(String storeId) async {
+    final photoModels = await _localDatasource.getPhotosByStoreId(storeId);
+    return photoModels.cast<Photo>();
+  }
+
+  @override
+  Future<List<Photo>> getPhotosByVisitId(String visitId) async {
+    final photoModels = await _localDatasource.getPhotosByVisitId(visitId);
+    return photoModels.cast<Photo>();
+  }
+
+  @override
+  Future<Photo?> getPhotoById(String id) async {
+    final photoModel = await _localDatasource.getPhotoById(id);
+    return photoModel;
+  }
+
+  @override
+  Future<void> insertPhoto(Photo photo) async {
+    final photoModel = PhotoModel.fromEntity(photo);
+    await _localDatasource.insertPhoto(photoModel);
+  }
+
+  @override
+  Future<void> updatePhoto(Photo photo) async {
+    final photoModel = PhotoModel.fromEntity(photo);
+    await _localDatasource.updatePhoto(photoModel);
+  }
+
+  @override
+  Future<void> deletePhoto(String id) async {
+    await _localDatasource.deletePhoto(id);
+  }
+}

--- a/lib/data/repositories/store_repository_impl.dart
+++ b/lib/data/repositories/store_repository_impl.dart
@@ -1,0 +1,51 @@
+import '../../domain/entities/store.dart';
+import '../../domain/repositories/store_repository.dart';
+import '../datasources/store_local_datasource.dart';
+import '../models/store_model.dart';
+
+class StoreRepositoryImpl implements StoreRepository {
+  final StoreLocalDatasource _localDatasource;
+
+  StoreRepositoryImpl(this._localDatasource);
+
+  @override
+  Future<List<Store>> getAllStores() async {
+    final storeModels = await _localDatasource.getAllStores();
+    return storeModels.cast<Store>();
+  }
+
+  @override
+  Future<List<Store>> getStoresByStatus(StoreStatus status) async {
+    final storeModels = await _localDatasource.getStoresByStatus(status);
+    return storeModels.cast<Store>();
+  }
+
+  @override
+  Future<Store?> getStoreById(String id) async {
+    final storeModel = await _localDatasource.getStoreById(id);
+    return storeModel;
+  }
+
+  @override
+  Future<void> insertStore(Store store) async {
+    final storeModel = StoreModel.fromEntity(store);
+    await _localDatasource.insertStore(storeModel);
+  }
+
+  @override
+  Future<void> updateStore(Store store) async {
+    final storeModel = StoreModel.fromEntity(store);
+    await _localDatasource.updateStore(storeModel);
+  }
+
+  @override
+  Future<void> deleteStore(String id) async {
+    await _localDatasource.deleteStore(id);
+  }
+
+  @override
+  Future<List<Store>> searchStores(String query) async {
+    final storeModels = await _localDatasource.searchStores(query);
+    return storeModels.cast<Store>();
+  }
+}

--- a/lib/data/repositories/store_repository_impl.dart
+++ b/lib/data/repositories/store_repository_impl.dart
@@ -1,12 +1,16 @@
 import '../../domain/entities/store.dart';
+import '../../domain/entities/photo.dart';
 import '../../domain/repositories/store_repository.dart';
 import '../datasources/store_local_datasource.dart';
 import '../models/store_model.dart';
+import '../models/photo_model.dart';
+import '../../core/database/database_helper.dart';
 
 class StoreRepositoryImpl implements StoreRepository {
   final StoreLocalDatasource _localDatasource;
+  final DatabaseHelper _databaseHelper;
 
-  StoreRepositoryImpl(this._localDatasource);
+  StoreRepositoryImpl(this._localDatasource, this._databaseHelper);
 
   @override
   Future<List<Store>> getAllStores() async {
@@ -47,5 +51,74 @@ class StoreRepositoryImpl implements StoreRepository {
   Future<List<Store>> searchStores(String query) async {
     final storeModels = await _localDatasource.searchStores(query);
     return storeModels.cast<Store>();
+  }
+
+  // ページネーション対応メソッド
+  Future<List<Store>> getStoresPaginated({
+    int page = 0,
+    int pageSize = 20,
+  }) async {
+    final storeModels = await _localDatasource.getStoresPaginated(
+      page: page,
+      pageSize: pageSize,
+    );
+    return storeModels.cast<Store>();
+  }
+
+  // トランザクション対応メソッド
+  Future<void> insertStoreWithPhotos(
+    Store store,
+    List<Photo> photos,
+  ) async {
+    try {
+      final db = await _databaseHelper.database;
+      await db.transaction((txn) async {
+        // Store insertion
+        await txn.insert(
+          'stores',
+          StoreModel.fromEntity(store).toMap(),
+        );
+
+        // Photos insertion
+        for (final photo in photos) {
+          await txn.insert(
+            'photos',
+            PhotoModel.fromEntity(photo).toMap(),
+          );
+        }
+      });
+    } catch (e) {
+      throw Exception('Failed to insert store with photos: ${e.toString()}');
+    }
+  }
+
+  Future<void> deleteStoreWithRelatedData(String storeId) async {
+    try {
+      final db = await _databaseHelper.database;
+      await db.transaction((txn) async {
+        // Delete related photos first
+        await txn.delete(
+          'photos',
+          where: 'store_id = ?',
+          whereArgs: [storeId],
+        );
+
+        // Delete related visit records
+        await txn.delete(
+          'visit_records',
+          where: 'store_id = ?',
+          whereArgs: [storeId],
+        );
+
+        // Finally delete the store
+        await txn.delete(
+          'stores',
+          where: 'id = ?',
+          whereArgs: [storeId],
+        );
+      });
+    } catch (e) {
+      throw Exception('Failed to delete store with related data: ${e.toString()}');
+    }
   }
 }

--- a/lib/data/repositories/visit_record_repository_impl.dart
+++ b/lib/data/repositories/visit_record_repository_impl.dart
@@ -1,0 +1,45 @@
+import '../../domain/entities/visit_record.dart';
+import '../../domain/repositories/visit_record_repository.dart';
+import '../datasources/visit_record_local_datasource.dart';
+import '../models/visit_record_model.dart';
+
+class VisitRecordRepositoryImpl implements VisitRecordRepository {
+  final VisitRecordLocalDatasource _localDatasource;
+
+  VisitRecordRepositoryImpl(this._localDatasource);
+
+  @override
+  Future<List<VisitRecord>> getAllVisitRecords() async {
+    final visitRecordModels = await _localDatasource.getAllVisitRecords();
+    return visitRecordModels.cast<VisitRecord>();
+  }
+
+  @override
+  Future<List<VisitRecord>> getVisitRecordsByStoreId(String storeId) async {
+    final visitRecordModels = await _localDatasource.getVisitRecordsByStoreId(storeId);
+    return visitRecordModels.cast<VisitRecord>();
+  }
+
+  @override
+  Future<VisitRecord?> getVisitRecordById(String id) async {
+    final visitRecordModel = await _localDatasource.getVisitRecordById(id);
+    return visitRecordModel;
+  }
+
+  @override
+  Future<void> insertVisitRecord(VisitRecord visitRecord) async {
+    final visitRecordModel = VisitRecordModel.fromEntity(visitRecord);
+    await _localDatasource.insertVisitRecord(visitRecordModel);
+  }
+
+  @override
+  Future<void> updateVisitRecord(VisitRecord visitRecord) async {
+    final visitRecordModel = VisitRecordModel.fromEntity(visitRecord);
+    await _localDatasource.updateVisitRecord(visitRecordModel);
+  }
+
+  @override
+  Future<void> deleteVisitRecord(String id) async {
+    await _localDatasource.deleteVisitRecord(id);
+  }
+}

--- a/lib/domain/repositories/photo_repository.dart
+++ b/lib/domain/repositories/photo_repository.dart
@@ -1,0 +1,11 @@
+import '../entities/photo.dart';
+
+abstract class PhotoRepository {
+  Future<List<Photo>> getAllPhotos();
+  Future<List<Photo>> getPhotosByStoreId(String storeId);
+  Future<List<Photo>> getPhotosByVisitId(String visitId);
+  Future<Photo?> getPhotoById(String id);
+  Future<void> insertPhoto(Photo photo);
+  Future<void> updatePhoto(Photo photo);
+  Future<void> deletePhoto(String id);
+}

--- a/lib/domain/repositories/store_repository.dart
+++ b/lib/domain/repositories/store_repository.dart
@@ -1,0 +1,11 @@
+import '../entities/store.dart';
+
+abstract class StoreRepository {
+  Future<List<Store>> getAllStores();
+  Future<List<Store>> getStoresByStatus(StoreStatus status);
+  Future<Store?> getStoreById(String id);
+  Future<void> insertStore(Store store);
+  Future<void> updateStore(Store store);
+  Future<void> deleteStore(String id);
+  Future<List<Store>> searchStores(String query);
+}

--- a/lib/domain/repositories/visit_record_repository.dart
+++ b/lib/domain/repositories/visit_record_repository.dart
@@ -1,0 +1,10 @@
+import '../entities/visit_record.dart';
+
+abstract class VisitRecordRepository {
+  Future<List<VisitRecord>> getAllVisitRecords();
+  Future<List<VisitRecord>> getVisitRecordsByStoreId(String storeId);
+  Future<VisitRecord?> getVisitRecordById(String id);
+  Future<void> insertVisitRecord(VisitRecord visitRecord);
+  Future<void> updateVisitRecord(VisitRecord visitRecord);
+  Future<void> deleteVisitRecord(String id);
+}


### PR DESCRIPTION
## 実装内容
- **DatabaseHelper**: SQLiteデータベースの初期化とスキーマ管理
- **データモデル**: Store、VisitRecord、Photoの完全なCRUDモデル
- **リポジトリパターン**: ドメイン層とデータ層の分離
- **ローカルデータソース**: 各エンティティのSQLite操作

## データベーススキーマ
- `stores`: 店舗情報（id, name, address, lat, lng, status, memo, created_at）
- `visit_records`: 訪問記録（id, store_id, visited_at, menu, memo, created_at）
- `photos`: 写真管理（id, store_id, visit_id, file_path, created_at）
- インデックス最適化済み

## アーキテクチャ
- Clean Architecture準拠
- Repository Pattern実装
- エンティティ⇔モデル変換対応
- Foreign Key制約とインデックス設計

🤖 Generated with [Claude Code](https://claude.ai/code)