### PR TITLE
feat: Issue #55 - 設定管理の集約化と分野別設定クラスの実装

### DIFF
--- a/lib/core/config/api_config.dart
+++ b/lib/core/config/api_config.dart
@@ -23,19 +23,27 @@ class ApiConfig {
     'Content-Type': 'application/json',
   };
 
-  /// API設定の妥当性チェック
+  /// 検証用定数
+  static const int minTimeoutSeconds = 1;
+  static const int maxTimeoutSeconds = 60;
+  static const int minRetryCount = 0;
+  static const int maxRetryCount = 5;
+  static const int minMaxResults = 1;
+  static const int maxMaxResults = 100;
+
+  /// タイムアウト値の妥当性チェック（1-60秒）
   static bool isValidTimeout(int timeout) {
-    return timeout > 0 && timeout <= 60;
+    return timeout >= minTimeoutSeconds && timeout <= maxTimeoutSeconds;
   }
 
-  /// API設定の妥当性チェック
+  /// リトライ回数の妥当性チェック（0-5回）
   static bool isValidRetryCount(int retryCount) {
-    return retryCount >= 0 && retryCount <= 5;
+    return retryCount >= minRetryCount && retryCount <= maxRetryCount;
   }
 
-  /// API設定の妥当性チェック
+  /// 最大結果数の妥当性チェック（1-100件）
   static bool isValidMaxResults(int maxResults) {
-    return maxResults > 0 && maxResults <= 100;
+    return maxResults >= minMaxResults && maxResults <= maxMaxResults;
   }
 
   /// デバッグ情報を取得

--- a/lib/core/config/api_config.dart
+++ b/lib/core/config/api_config.dart
@@ -1,0 +1,56 @@
+/// API関連の設定を管理するクラス
+class ApiConfig {
+  /// HotPepper API設定
+  static const String hotpepperApiUrl =
+      'https://webservice.recruit.co.jp/hotpepper/gourmet/v1/';
+  static const int hotpepperApiTimeout = 10; // 秒
+  static const int hotpepperApiRetryCount = 3;
+  static const int hotpepperMaxResults = 100;
+  static const int hotpepperRateLimit = 5; // 1秒間のリクエスト数制限
+  static const int hotpepperDailyLimit = 3000; // 1日のリクエスト数制限
+
+  /// Google Maps API設定
+  static const String googleMapsApiUrl =
+      'https://maps.googleapis.com/maps/api/';
+  static const int googleMapsApiTimeout = 15; // 秒
+  static const int googleMapsApiRetryCount = 2;
+
+  /// 共通API設定
+  static const String userAgent = 'MachiApp/1.0.0';
+  static const Map<String, String> commonHeaders = {
+    'User-Agent': userAgent,
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+  };
+
+  /// API設定の妥当性チェック
+  static bool isValidTimeout(int timeout) {
+    return timeout > 0 && timeout <= 60;
+  }
+
+  /// API設定の妥当性チェック
+  static bool isValidRetryCount(int retryCount) {
+    return retryCount >= 0 && retryCount <= 5;
+  }
+
+  /// API設定の妥当性チェック
+  static bool isValidMaxResults(int maxResults) {
+    return maxResults > 0 && maxResults <= 100;
+  }
+
+  /// デバッグ情報を取得
+  static Map<String, dynamic> get debugInfo {
+    return {
+      'hotpepperApiUrl': hotpepperApiUrl,
+      'hotpepperApiTimeout': hotpepperApiTimeout,
+      'hotpepperApiRetryCount': hotpepperApiRetryCount,
+      'hotpepperMaxResults': hotpepperMaxResults,
+      'hotpepperRateLimit': hotpepperRateLimit,
+      'hotpepperDailyLimit': hotpepperDailyLimit,
+      'googleMapsApiUrl': googleMapsApiUrl,
+      'googleMapsApiTimeout': googleMapsApiTimeout,
+      'googleMapsApiRetryCount': googleMapsApiRetryCount,
+      'userAgent': userAgent,
+    };
+  }
+}

--- a/lib/core/config/config_manager.dart
+++ b/lib/core/config/config_manager.dart
@@ -1,9 +1,14 @@
 import 'dart:async';
 import 'dart:developer' as developer;
 
+import 'api_config.dart';
 import 'config_exception.dart';
 import 'config_validator.dart';
+import 'database_config.dart';
 import 'environment_config.dart';
+import 'location_config.dart';
+import 'search_config.dart';
+import 'ui_config.dart';
 
 /// 設定管理クラス
 ///
@@ -269,5 +274,156 @@ ConfigManager 設定情報:
   /// 設定変更の通知を停止（テスト用）
   static void dispose() {
     _configChangeController.close();
+  }
+
+  // === 分野別設定アクセス ===
+
+  /// API設定を取得
+  static Map<String, dynamic> get apiConfig {
+    return ApiConfig.debugInfo;
+  }
+
+  /// 位置情報設定を取得
+  static Map<String, dynamic> get locationConfig {
+    return LocationConfig.debugInfo;
+  }
+
+  /// 検索設定を取得
+  static Map<String, dynamic> get searchConfig {
+    return SearchConfig.debugInfo;
+  }
+
+  /// UI設定を取得
+  static Map<String, dynamic> get uiConfig {
+    return UiConfig.debugInfo;
+  }
+
+  /// データベース設定を取得
+  static Map<String, dynamic> get databaseConfig {
+    return DatabaseConfig.debugInfo;
+  }
+
+  /// 全設定情報を統合して取得
+  static Map<String, dynamic> get allConfigs {
+    _ensureInitialized();
+    return {
+      'runtime': _runtimeConfig,
+      'api': apiConfig,
+      'location': locationConfig,
+      'search': searchConfig,
+      'ui': uiConfig,
+      'database': databaseConfig,
+    };
+  }
+
+  /// 設定の整合性チェック
+  static Map<String, List<String>> validateAllConfigs() {
+    _ensureInitialized();
+    return {
+      'runtime': validateConfiguration(),
+      'api': _validateApiConfig(),
+      'location': _validateLocationConfig(),
+      'search': _validateSearchConfig(),
+      'ui': _validateUiConfig(),
+      'database': _validateDatabaseConfig(),
+    };
+  }
+
+  /// API設定の検証
+  static List<String> _validateApiConfig() {
+    final errors = <String>[];
+
+    if (!ApiConfig.isValidTimeout(ApiConfig.hotpepperApiTimeout)) {
+      errors.add('HotPepper APIタイムアウト値が無効です: ${ApiConfig.hotpepperApiTimeout}');
+    }
+
+    if (!ApiConfig.isValidRetryCount(ApiConfig.hotpepperApiRetryCount)) {
+      errors
+          .add('HotPepper APIリトライ回数が無効です: ${ApiConfig.hotpepperApiRetryCount}');
+    }
+
+    if (!ApiConfig.isValidMaxResults(ApiConfig.hotpepperMaxResults)) {
+      errors.add('HotPepper API最大結果数が無効です: ${ApiConfig.hotpepperMaxResults}');
+    }
+
+    return errors;
+  }
+
+  /// 位置情報設定の検証
+  static List<String> _validateLocationConfig() {
+    final errors = <String>[];
+
+    if (!LocationConfig.isValidTimeout(LocationConfig.defaultTimeoutSeconds)) {
+      errors.add('位置情報タイムアウト値が無効です: ${LocationConfig.defaultTimeoutSeconds}');
+    }
+
+    if (!LocationConfig.isValidRadius(LocationConfig.defaultLocationRadius)) {
+      errors.add('位置情報検索半径が無効です: ${LocationConfig.defaultLocationRadius}');
+    }
+
+    if (!LocationConfig.isValidUpdateInterval(
+        LocationConfig.locationUpdateInterval)) {
+      errors.add('位置情報更新間隔が無効です: ${LocationConfig.locationUpdateInterval}');
+    }
+
+    return errors;
+  }
+
+  /// 検索設定の検証
+  static List<String> _validateSearchConfig() {
+    final errors = <String>[];
+
+    if (!SearchConfig.isValidRange(SearchConfig.defaultRange)) {
+      errors.add('検索範囲が無効です: ${SearchConfig.defaultRange}');
+    }
+
+    if (!SearchConfig.isValidCount(SearchConfig.defaultCount)) {
+      errors.add('検索結果数が無効です: ${SearchConfig.defaultCount}');
+    }
+
+    if (!SearchConfig.isValidKeyword(SearchConfig.defaultKeyword)) {
+      errors.add('検索キーワードが無効です: ${SearchConfig.defaultKeyword}');
+    }
+
+    return errors;
+  }
+
+  /// UI設定の検証
+  static List<String> _validateUiConfig() {
+    final errors = <String>[];
+
+    if (!UiConfig.isValidPadding(UiConfig.defaultPadding)) {
+      errors.add('UIパディング値が無効です: ${UiConfig.defaultPadding}');
+    }
+
+    if (!UiConfig.isValidBorderRadius(UiConfig.cardBorderRadius)) {
+      errors.add('カード角丸値が無効です: ${UiConfig.cardBorderRadius}');
+    }
+
+    if (!UiConfig.isValidMapZoom(UiConfig.defaultMapZoom)) {
+      errors.add('マップズーム値が無効です: ${UiConfig.defaultMapZoom}');
+    }
+
+    return errors;
+  }
+
+  /// データベース設定の検証
+  static List<String> _validateDatabaseConfig() {
+    final errors = <String>[];
+
+    if (!DatabaseConfig.isValidDatabaseVersion(
+        DatabaseConfig.databaseVersion)) {
+      errors.add('データベースバージョンが無効です: ${DatabaseConfig.databaseVersion}');
+    }
+
+    if (!DatabaseConfig.isValidCacheSize(DatabaseConfig.cacheSize)) {
+      errors.add('データベースキャッシュサイズが無効です: ${DatabaseConfig.cacheSize}');
+    }
+
+    if (!DatabaseConfig.isValidPageSize(DatabaseConfig.pageSize)) {
+      errors.add('データベースページサイズが無効です: ${DatabaseConfig.pageSize}');
+    }
+
+    return errors;
   }
 }

--- a/lib/core/config/config_manager.dart
+++ b/lib/core/config/config_manager.dart
@@ -209,6 +209,12 @@ class ConfigManager {
     return _runtimeConfig['hasCriticalErrors'] as bool;
   }
 
+  /// 全設定検証でCriticalエラーがあるかを判定
+  static bool get hasAnyCriticalErrors {
+    _ensureInitialized();
+    return ConfigValidator.hasAnyCriticalErrors;
+  }
+
   /// APIキーが有効かどうかを判定（既存のAppConstantsとの互換性）
   static bool get hasValidApiKeys {
     _ensureInitialized();

--- a/lib/core/config/config_validator.dart
+++ b/lib/core/config/config_validator.dart
@@ -1,4 +1,9 @@
+import 'api_config.dart';
+import 'database_config.dart';
 import 'environment_config.dart';
+import 'location_config.dart';
+import 'search_config.dart';
+import 'ui_config.dart';
 
 /// 設定検証クラス
 class ConfigValidator {
@@ -14,6 +19,9 @@ class ConfigValidator {
 
     // 環境固有の検証
     _validateEnvironmentSpecificConfig(errors);
+
+    // 分野別設定の検証
+    _validateDomainConfigs(errors);
 
     return errors;
   }
@@ -163,11 +171,136 @@ class ConfigValidator {
         error.contains('警告: 本番環境'));
   }
 
+  /// 分野別設定の検証
+  static void _validateDomainConfigs(List<String> errors) {
+    // API設定の検証
+    _validateApiConfigSettings(errors);
+
+    // 位置情報設定の検証
+    _validateLocationConfigSettings(errors);
+
+    // 検索設定の検証
+    _validateSearchConfigSettings(errors);
+
+    // UI設定の検証
+    _validateUiConfigSettings(errors);
+
+    // データベース設定の検証
+    _validateDatabaseConfigSettings(errors);
+  }
+
+  /// API設定の検証
+  static void _validateApiConfigSettings(List<String> errors) {
+    if (!ApiConfig.isValidTimeout(ApiConfig.hotpepperApiTimeout)) {
+      errors.add(
+          'API設定: HotPepper APIタイムアウト値が無効です (${ApiConfig.hotpepperApiTimeout}秒)');
+    }
+
+    if (!ApiConfig.isValidRetryCount(ApiConfig.hotpepperApiRetryCount)) {
+      errors.add(
+          'API設定: HotPepper APIリトライ回数が無効です (${ApiConfig.hotpepperApiRetryCount}回)');
+    }
+
+    if (!ApiConfig.isValidMaxResults(ApiConfig.hotpepperMaxResults)) {
+      errors.add(
+          'API設定: HotPepper API最大結果数が無効です (${ApiConfig.hotpepperMaxResults}件)');
+    }
+  }
+
+  /// 位置情報設定の検証
+  static void _validateLocationConfigSettings(List<String> errors) {
+    if (!LocationConfig.isValidTimeout(LocationConfig.defaultTimeoutSeconds)) {
+      errors.add(
+          '位置情報設定: タイムアウト値が無効です (${LocationConfig.defaultTimeoutSeconds}秒)');
+    }
+
+    if (!LocationConfig.isValidRadius(LocationConfig.defaultLocationRadius)) {
+      errors
+          .add('位置情報設定: 検索半径が無効です (${LocationConfig.defaultLocationRadius}m)');
+    }
+
+    if (!LocationConfig.isValidUpdateInterval(
+        LocationConfig.locationUpdateInterval)) {
+      errors
+          .add('位置情報設定: 更新間隔が無効です (${LocationConfig.locationUpdateInterval}秒)');
+    }
+  }
+
+  /// 検索設定の検証
+  static void _validateSearchConfigSettings(List<String> errors) {
+    if (!SearchConfig.isValidRange(SearchConfig.defaultRange)) {
+      errors.add('検索設定: 検索範囲が無効です (${SearchConfig.defaultRange})');
+    }
+
+    if (!SearchConfig.isValidCount(SearchConfig.defaultCount)) {
+      errors.add('検索設定: 検索結果数が無効です (${SearchConfig.defaultCount}件)');
+    }
+
+    if (!SearchConfig.isValidKeyword(SearchConfig.defaultKeyword)) {
+      errors.add('検索設定: デフォルトキーワードが無効です (${SearchConfig.defaultKeyword})');
+    }
+  }
+
+  /// UI設定の検証
+  static void _validateUiConfigSettings(List<String> errors) {
+    if (!UiConfig.isValidPadding(UiConfig.defaultPadding)) {
+      errors.add('UI設定: デフォルトパディングが無効です (${UiConfig.defaultPadding})');
+    }
+
+    if (!UiConfig.isValidBorderRadius(UiConfig.cardBorderRadius)) {
+      errors.add('UI設定: カード角丸値が無効です (${UiConfig.cardBorderRadius})');
+    }
+
+    if (!UiConfig.isValidMapZoom(UiConfig.defaultMapZoom)) {
+      errors.add('UI設定: デフォルトマップズームが無効です (${UiConfig.defaultMapZoom})');
+    }
+  }
+
+  /// データベース設定の検証
+  static void _validateDatabaseConfigSettings(List<String> errors) {
+    if (!DatabaseConfig.isValidDatabaseVersion(
+        DatabaseConfig.databaseVersion)) {
+      errors.add('データベース設定: バージョンが無効です (${DatabaseConfig.databaseVersion})');
+    }
+
+    if (!DatabaseConfig.isValidCacheSize(DatabaseConfig.cacheSize)) {
+      errors.add('データベース設定: キャッシュサイズが無効です (${DatabaseConfig.cacheSize})');
+    }
+
+    if (!DatabaseConfig.isValidPageSize(DatabaseConfig.pageSize)) {
+      errors.add('データベース設定: ページサイズが無効です (${DatabaseConfig.pageSize})');
+    }
+  }
+
+  /// 全分野別設定の検証結果を取得
+  static Map<String, List<String>> validateAllDomainConfigs() {
+    final result = <String, List<String>>{};
+
+    // 各分野別の検証
+    result['api'] = [];
+    _validateApiConfigSettings(result['api']!);
+
+    result['location'] = [];
+    _validateLocationConfigSettings(result['location']!);
+
+    result['search'] = [];
+    _validateSearchConfigSettings(result['search']!);
+
+    result['ui'] = [];
+    _validateUiConfigSettings(result['ui']!);
+
+    result['database'] = [];
+    _validateDatabaseConfigSettings(result['database']!);
+
+    return result;
+  }
+
   /// 設定の詳細情報を取得（デバッグ用）
   static Map<String, dynamic> get configurationDetails {
     return {
       'environment': EnvironmentConfig.current.name,
       'validationErrors': validateConfiguration(),
+      'domainValidationErrors': validateAllDomainConfigs(),
       'isValid': isConfigurationValid,
       'hasCriticalErrors': hasCriticalErrors,
       'debugInfo': EnvironmentConfig.debugInfo,

--- a/lib/core/config/config_validator.dart
+++ b/lib/core/config/config_validator.dart
@@ -171,6 +171,31 @@ class ConfigValidator {
         error.contains('警告: 本番環境'));
   }
 
+  /// 全設定検証でCriticalエラーがあるかを判定
+  static bool get hasAnyCriticalErrors {
+    final validationResults = validateAllDomainConfigs();
+    final runtimeErrors = validateConfiguration();
+
+    // ランタイム設定のCriticalエラーチェック
+    final hasCriticalRuntimeErrors = runtimeErrors.any((error) =>
+        error.contains('本番環境') ||
+        error.contains('形式が無効') ||
+        error.contains('警告: 本番環境'));
+
+    // 分野別設定のCriticalエラーチェック
+    final hasCriticalDomainErrors = validationResults.values
+        .any((errors) => errors.any((error) => _isCriticalError(error)));
+
+    return hasCriticalRuntimeErrors || hasCriticalDomainErrors;
+  }
+
+  /// エラーがCriticalレベルかどうかを判定
+  static bool _isCriticalError(String error) {
+    return error.contains('データベース設定: バージョンが無効') ||
+        error.contains('API設定: HotPepper APIタイムアウト値が無効') ||
+        error.contains('位置情報設定: タイムアウト値が無効');
+  }
+
   /// 分野別設定の検証
   static void _validateDomainConfigs(List<String> errors) {
     // API設定の検証

--- a/lib/core/config/database_config.dart
+++ b/lib/core/config/database_config.dart
@@ -1,0 +1,131 @@
+/// データベース関連の設定を管理するクラス
+class DatabaseConfig {
+  /// データベース設定
+  static const String databaseName = 'machiapp.db';
+  static const int databaseVersion = 2;
+
+  /// データベースファイルパス設定
+  static const String databasePath = 'databases';
+
+  /// データベースのテーブル設定
+  static const List<String> tableNames = [
+    'stores',
+    'visit_records',
+    'photos',
+  ];
+
+  /// Foreign Key制約設定
+  static const bool enableForeignKeys = true;
+
+  /// WALモード設定（パフォーマンス向上）
+  static const bool enableWalMode = true;
+
+  /// 同期設定
+  static const String synchronousMode = 'NORMAL'; // OFF, NORMAL, FULL
+
+  /// キャッシュ設定
+  static const int cacheSize = 1000; // ページ数
+  static const int pageSize = 4096; // バイト
+
+  /// トランザクション設定
+  static const int transactionTimeout = 30; // 秒
+  static const int maxTransactionRetries = 3;
+
+  /// バックアップ設定
+  static const bool enableAutoBackup = true;
+  static const int backupInterval = 24; // 時間
+  static const int maxBackupFiles = 7;
+
+  /// インデックス設定
+  static const List<String> optimizedIndexes = [
+    'idx_stores_lat_lng',
+    'idx_stores_status',
+    'idx_visit_records_store_id',
+    'idx_visit_records_visited_at',
+    'idx_photos_store_id',
+    'idx_photos_visit_id',
+  ];
+
+  /// データベースの整合性チェック設定
+  static const bool enableIntegrityCheck = true;
+  static const int integrityCheckInterval = 7; // 日
+
+  /// バキューム設定
+  static const bool enableAutoVacuum = true;
+  static const int vacuumInterval = 30; // 日
+
+  /// 設定値の妥当性チェック
+  static bool isValidDatabaseVersion(int version) {
+    return version > 0 && version <= 100;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidCacheSize(int size) {
+    return size >= 100 && size <= 10000;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidPageSize(int size) {
+    return [1024, 2048, 4096, 8192, 16384, 32768, 65536].contains(size);
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidTransactionTimeout(int timeout) {
+    return timeout >= 1 && timeout <= 300;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidMaxRetries(int retries) {
+    return retries >= 0 && retries <= 10;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidInterval(int interval) {
+    return interval >= 1 && interval <= 168; // 1時間から1週間
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidBackupFiles(int files) {
+    return files >= 1 && files <= 30;
+  }
+
+  /// テーブル名が有効かどうかを判定
+  static bool isValidTableName(String tableName) {
+    return tableNames.contains(tableName);
+  }
+
+  /// インデックス名が有効かどうかを判定
+  static bool isValidIndexName(String indexName) {
+    return optimizedIndexes.contains(indexName);
+  }
+
+  /// 同期モードが有効かどうかを判定
+  static bool isValidSynchronousMode(String mode) {
+    return ['OFF', 'NORMAL', 'FULL'].contains(mode.toUpperCase());
+  }
+
+  /// デバッグ情報を取得
+  static Map<String, dynamic> get debugInfo {
+    return {
+      'databaseName': databaseName,
+      'databaseVersion': databaseVersion,
+      'databasePath': databasePath,
+      'tableNames': tableNames,
+      'enableForeignKeys': enableForeignKeys,
+      'enableWalMode': enableWalMode,
+      'synchronousMode': synchronousMode,
+      'cacheSize': cacheSize,
+      'pageSize': pageSize,
+      'transactionTimeout': transactionTimeout,
+      'maxTransactionRetries': maxTransactionRetries,
+      'enableAutoBackup': enableAutoBackup,
+      'backupInterval': backupInterval,
+      'maxBackupFiles': maxBackupFiles,
+      'optimizedIndexes': optimizedIndexes,
+      'enableIntegrityCheck': enableIntegrityCheck,
+      'integrityCheckInterval': integrityCheckInterval,
+      'enableAutoVacuum': enableAutoVacuum,
+      'vacuumInterval': vacuumInterval,
+    };
+  }
+}

--- a/lib/core/config/location_config.dart
+++ b/lib/core/config/location_config.dart
@@ -1,0 +1,100 @@
+import 'package:geolocator/geolocator.dart';
+
+/// 位置情報関連の設定を管理するクラス
+class LocationConfig {
+  /// 位置情報取得のタイムアウト時間（秒）
+  static const int defaultTimeoutSeconds = 10;
+  static const int maxTimeoutSeconds = 60;
+  static const int minTimeoutSeconds = 1;
+
+  /// 位置情報の精度設定
+  static const LocationAccuracy defaultAccuracy = LocationAccuracy.high;
+  static const LocationAccuracy fallbackAccuracy = LocationAccuracy.medium;
+
+  /// 位置情報の権限設定
+  static const List<LocationPermission> acceptablePermissions = [
+    LocationPermission.whileInUse,
+    LocationPermission.always,
+  ];
+
+  /// 位置情報の距離設定
+  static const double defaultLocationRadius = 1000.0; // メートル
+  static const double minLocationRadius = 100.0; // メートル
+  static const double maxLocationRadius = 10000.0; // メートル
+
+  /// 位置情報の精度設定
+  static const double minAcceptableAccuracy = 100.0; // メートル
+  static const double maxAcceptableAccuracy = 1000.0; // メートル
+
+  /// 位置情報の再取得間隔（秒）
+  static const int locationUpdateInterval = 30;
+  static const int minUpdateInterval = 5;
+  static const int maxUpdateInterval = 300;
+
+  /// 位置情報の設定値検証
+  static bool isValidTimeout(int timeout) {
+    return timeout >= minTimeoutSeconds && timeout <= maxTimeoutSeconds;
+  }
+
+  /// 位置情報の設定値検証
+  static bool isValidRadius(double radius) {
+    return radius >= minLocationRadius && radius <= maxLocationRadius;
+  }
+
+  /// 位置情報の設定値検証
+  static bool isValidAccuracy(double accuracy) {
+    return accuracy >= minAcceptableAccuracy &&
+        accuracy <= maxAcceptableAccuracy;
+  }
+
+  /// 位置情報の設定値検証
+  static bool isValidUpdateInterval(int interval) {
+    return interval >= minUpdateInterval && interval <= maxUpdateInterval;
+  }
+
+  /// 権限が許可されているかどうかを判定
+  static bool isPermissionAcceptable(LocationPermission permission) {
+    return acceptablePermissions.contains(permission);
+  }
+
+  /// 位置情報の精度レベルを取得
+  static LocationAccuracy getAccuracyLevel(String accuracyName) {
+    switch (accuracyName.toLowerCase()) {
+      case 'lowest':
+        return LocationAccuracy.lowest;
+      case 'low':
+        return LocationAccuracy.low;
+      case 'medium':
+        return LocationAccuracy.medium;
+      case 'high':
+        return LocationAccuracy.high;
+      case 'best':
+        return LocationAccuracy.best;
+      case 'bestfornavigation':
+        return LocationAccuracy.bestForNavigation;
+      default:
+        return defaultAccuracy;
+    }
+  }
+
+  /// デバッグ情報を取得
+  static Map<String, dynamic> get debugInfo {
+    return {
+      'defaultTimeoutSeconds': defaultTimeoutSeconds,
+      'maxTimeoutSeconds': maxTimeoutSeconds,
+      'minTimeoutSeconds': minTimeoutSeconds,
+      'defaultAccuracy': defaultAccuracy.name,
+      'fallbackAccuracy': fallbackAccuracy.name,
+      'acceptablePermissions':
+          acceptablePermissions.map((p) => p.name).toList(),
+      'defaultLocationRadius': defaultLocationRadius,
+      'minLocationRadius': minLocationRadius,
+      'maxLocationRadius': maxLocationRadius,
+      'minAcceptableAccuracy': minAcceptableAccuracy,
+      'maxAcceptableAccuracy': maxAcceptableAccuracy,
+      'locationUpdateInterval': locationUpdateInterval,
+      'minUpdateInterval': minUpdateInterval,
+      'maxUpdateInterval': maxUpdateInterval,
+    };
+  }
+}

--- a/lib/core/config/search_config.dart
+++ b/lib/core/config/search_config.dart
@@ -1,0 +1,129 @@
+/// 検索関連の設定を管理するクラス
+class SearchConfig {
+  /// 検索デフォルト設定
+  static const String defaultKeyword = '中華';
+  static const int defaultRange =
+      3; // 1:300m, 2:500m, 3:1000m, 4:2000m, 5:3000m
+  static const int defaultCount = 20;
+  static const int defaultStart = 1;
+
+  /// 検索範囲設定
+  static const Map<int, int> rangeToMeters = {
+    1: 300,
+    2: 500,
+    3: 1000,
+    4: 2000,
+    5: 3000,
+  };
+
+  /// 検索結果の取得件数設定
+  static const int minCount = 1;
+  static const int maxCount = 100;
+  static const int defaultPageSize = 20;
+
+  /// 検索開始位置設定
+  static const int minStart = 1;
+  static const int maxStart = 1000;
+
+  /// 検索キーワード設定
+  static const List<String> allowedKeywords = [
+    '中華',
+    '中華料理',
+    '町中華',
+    '餃子',
+    'ラーメン',
+    '炒飯',
+    '炒め物',
+    '麺類',
+    '定食',
+  ];
+
+  /// 検索フィルタ設定
+  static const List<String> budgetRanges = [
+    '～500円',
+    '501～1000円',
+    '1001～1500円',
+    '1501～2000円',
+    '2001～3000円',
+    '3001～4000円',
+    '4001～5000円',
+    '5001円～',
+  ];
+
+  /// 検索ソート設定
+  static const List<String> sortOptions = [
+    'distance', // 距離順
+    'rating', // 評価順
+    'budget', // 予算順
+    'name', // 店名順
+  ];
+
+  /// 検索設定の妥当性チェック
+  static bool isValidRange(int range) {
+    return rangeToMeters.containsKey(range);
+  }
+
+  /// 検索設定の妥当性チェック
+  static bool isValidCount(int count) {
+    return count >= minCount && count <= maxCount;
+  }
+
+  /// 検索設定の妥当性チェック
+  static bool isValidStart(int start) {
+    return start >= minStart && start <= maxStart;
+  }
+
+  /// 検索設定の妥当性チェック
+  static bool isValidKeyword(String keyword) {
+    return keyword.isNotEmpty && keyword.length <= 100;
+  }
+
+  /// 検索キーワードが許可されているかどうかを判定
+  static bool isAllowedKeyword(String keyword) {
+    return allowedKeywords.contains(keyword);
+  }
+
+  /// 検索範囲をメートルに変換
+  static int? rangeToMeter(int range) {
+    return rangeToMeters[range];
+  }
+
+  /// メートルを検索範囲に変換
+  static int? meterToRange(int meter) {
+    for (final entry in rangeToMeters.entries) {
+      if (entry.value == meter) {
+        return entry.key;
+      }
+    }
+    return null;
+  }
+
+  /// 予算範囲が有効かどうかを判定
+  static bool isValidBudgetRange(String budgetRange) {
+    return budgetRanges.contains(budgetRange);
+  }
+
+  /// ソートオプションが有効かどうかを判定
+  static bool isValidSortOption(String sortOption) {
+    return sortOptions.contains(sortOption);
+  }
+
+  /// デバッグ情報を取得
+  static Map<String, dynamic> get debugInfo {
+    return {
+      'defaultKeyword': defaultKeyword,
+      'defaultRange': defaultRange,
+      'defaultCount': defaultCount,
+      'defaultStart': defaultStart,
+      'rangeToMeters': rangeToMeters,
+      'minCount': minCount,
+      'maxCount': maxCount,
+      'defaultPageSize': defaultPageSize,
+      'minStart': minStart,
+      'maxStart': maxStart,
+      'allowedKeywords': allowedKeywords,
+      'budgetRanges': budgetRanges,
+      'sortOptions': sortOptions,
+    };
+  }
+}

--- a/lib/core/config/ui_config.dart
+++ b/lib/core/config/ui_config.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+
+/// UI関連の設定を管理するクラス
+class UiConfig {
+  /// アプリ情報
+  static const String appName = 'マチアプ';
+  static const String appVersion = '1.0.0';
+  static const String appDescription = '町中華探索アプリ';
+
+  /// レイアウト設定
+  static const double cardBorderRadius = 12.0;
+  static const double defaultPadding = 16.0;
+  static const double smallPadding = 8.0;
+  static const double largePadding = 24.0;
+  static const double extraLargePadding = 32.0;
+
+  /// マージン設定
+  static const double defaultMargin = 16.0;
+  static const double smallMargin = 8.0;
+  static const double largeMargin = 24.0;
+
+  /// カード設定
+  static const double cardElevation = 4.0;
+  static const double cardMaxWidth = 400.0;
+  static const double cardMinHeight = 200.0;
+
+  /// ボタン設定
+  static const double buttonHeight = 48.0;
+  static const double buttonBorderRadius = 8.0;
+  static const double iconButtonSize = 24.0;
+
+  /// フォント設定
+  static const double titleFontSize = 24.0;
+  static const double subtitleFontSize = 18.0;
+  static const double bodyFontSize = 16.0;
+  static const double captionFontSize = 12.0;
+
+  /// アイコン設定
+  static const double defaultIconSize = 24.0;
+  static const double smallIconSize = 16.0;
+  static const double largeIconSize = 32.0;
+
+  /// 画像設定
+  static const double defaultImageSize = 100.0;
+  static const double thumbnailSize = 60.0;
+  static const double largeImageSize = 200.0;
+
+  /// アニメーション設定
+  static const Duration defaultAnimationDuration = Duration(milliseconds: 300);
+  static const Duration quickAnimationDuration = Duration(milliseconds: 150);
+  static const Duration slowAnimationDuration = Duration(milliseconds: 500);
+
+  /// スワイプ設定
+  static const double swipeThreshold = 0.3;
+  static const double swipeVelocityThreshold = 500.0;
+
+  /// 色設定
+  static const Color primaryColor = Color(0xFF2196F3);
+  static const Color secondaryColor = Color(0xFFFF9800);
+  static const Color errorColor = Color(0xFFFF5722);
+  static const Color successColor = Color(0xFF4CAF50);
+  static const Color warningColor = Color(0xFFFF9800);
+  static const Color backgroundColor = Color(0xFFF5F5F5);
+  static const Color cardBackgroundColor = Colors.white;
+  static const Color textColor = Color(0xFF333333);
+  static const Color subtitleColor = Color(0xFF666666);
+  static const Color dividerColor = Color(0xFFE0E0E0);
+
+  /// Google Maps設定
+  static const double defaultMapZoom = 15.0;
+  static const double minMapZoom = 10.0;
+  static const double maxMapZoom = 20.0;
+
+  /// 設定値の妥当性チェック
+  static bool isValidPadding(double padding) {
+    return padding >= 0 && padding <= 100;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidBorderRadius(double radius) {
+    return radius >= 0 && radius <= 50;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidFontSize(double fontSize) {
+    return fontSize >= 8 && fontSize <= 72;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidIconSize(double iconSize) {
+    return iconSize >= 12 && iconSize <= 100;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidImageSize(double imageSize) {
+    return imageSize >= 20 && imageSize <= 500;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidAnimationDuration(Duration duration) {
+    return duration.inMilliseconds >= 50 && duration.inMilliseconds <= 5000;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidSwipeThreshold(double threshold) {
+    return threshold >= 0.1 && threshold <= 1.0;
+  }
+
+  /// 設定値の妥当性チェック
+  static bool isValidMapZoom(double zoom) {
+    return zoom >= minMapZoom && zoom <= maxMapZoom;
+  }
+
+  /// デバッグ情報を取得
+  static Map<String, dynamic> get debugInfo {
+    return {
+      'appName': appName,
+      'appVersion': appVersion,
+      'appDescription': appDescription,
+      'cardBorderRadius': cardBorderRadius,
+      'defaultPadding': defaultPadding,
+      'smallPadding': smallPadding,
+      'largePadding': largePadding,
+      'extraLargePadding': extraLargePadding,
+      'defaultMargin': defaultMargin,
+      'smallMargin': smallMargin,
+      'largeMargin': largeMargin,
+      'cardElevation': cardElevation,
+      'cardMaxWidth': cardMaxWidth,
+      'cardMinHeight': cardMinHeight,
+      'buttonHeight': buttonHeight,
+      'buttonBorderRadius': buttonBorderRadius,
+      'iconButtonSize': iconButtonSize,
+      'titleFontSize': titleFontSize,
+      'subtitleFontSize': subtitleFontSize,
+      'bodyFontSize': bodyFontSize,
+      'captionFontSize': captionFontSize,
+      'defaultIconSize': defaultIconSize,
+      'smallIconSize': smallIconSize,
+      'largeIconSize': largeIconSize,
+      'defaultImageSize': defaultImageSize,
+      'thumbnailSize': thumbnailSize,
+      'largeImageSize': largeImageSize,
+      'defaultAnimationDuration': defaultAnimationDuration.inMilliseconds,
+      'quickAnimationDuration': quickAnimationDuration.inMilliseconds,
+      'slowAnimationDuration': slowAnimationDuration.inMilliseconds,
+      'swipeThreshold': swipeThreshold,
+      'swipeVelocityThreshold': swipeVelocityThreshold,
+      'primaryColor': primaryColor.toString(),
+      'secondaryColor': secondaryColor.toString(),
+      'errorColor': errorColor.toString(),
+      'successColor': successColor.toString(),
+      'warningColor': warningColor.toString(),
+      'backgroundColor': backgroundColor.toString(),
+      'cardBackgroundColor': cardBackgroundColor.toString(),
+      'textColor': textColor.toString(),
+      'subtitleColor': subtitleColor.toString(),
+      'dividerColor': dividerColor.toString(),
+      'defaultMapZoom': defaultMapZoom,
+      'minMapZoom': minMapZoom,
+      'maxMapZoom': maxMapZoom,
+    };
+  }
+}

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -1,26 +1,31 @@
+import 'dart:developer' as developer;
+
+import '../config/api_config.dart';
 import '../config/config_manager.dart';
+import '../config/database_config.dart';
+import '../config/ui_config.dart';
 
 /// アプリケーション定数クラス
 ///
-/// 注意: API関連の設定は ConfigManager を使用してください。
-/// このクラスは環境に依存しない固定値のみを定義します。
+/// 注意: 設定値は分野別設定クラス（ApiConfig、UiConfig等）を使用してください。
+/// このクラスは既存コードとの互換性維持のために残されています。
 class AppConstants {
-  // アプリ情報
-  static const String appName = 'マチアプ';
-  static const String appVersion = '1.0.0';
+  // アプリ情報 - UiConfigから取得
+  static String get appName => UiConfig.appName;
+  static String get appVersion => UiConfig.appVersion;
 
-  // データベース
-  static const String databaseName = 'machiapp.db';
-  static const int databaseVersion = 2;
+  // データベース - DatabaseConfigから取得
+  static String get databaseName => DatabaseConfig.databaseName;
+  static int get databaseVersion => DatabaseConfig.databaseVersion;
 
-  // UI関連
-  static const double cardBorderRadius = 12.0;
-  static const double defaultPadding = 16.0;
+  // UI関連 - UiConfigから取得
+  static double get cardBorderRadius => UiConfig.cardBorderRadius;
+  static double get defaultPadding => UiConfig.defaultPadding;
 
-  // API関連 - 環境別設定のため ConfigManager を使用
+  // API関連 - ConfigManagerから取得（環境別設定）
   /// HotPepper API ベースURL
-  /// 実際の使用時は ConfigManager.hotpepperApiUrl を使用してください
-  static String get hotpepperApiUrl => ConfigManager.hotpepperApiUrl;
+  /// 実際の使用時は ApiConfig.hotpepperApiUrl を使用してください
+  static String get hotpepperApiUrl => ApiConfig.hotpepperApiUrl;
 
   /// HotPepper API キー
   /// 実際の使用時は ConfigManager.hotpepperApiKey を使用してください
@@ -33,16 +38,17 @@ class AppConstants {
   /// APIキーが有効かどうかを判定（既存コードとの互換性維持）
   static bool get hasValidApiKeys => ConfigManager.hasValidApiKeys;
 
-  // HotPepper API 設定
-  static const int hotpepperApiTimeout = 10; // 秒
-  static const int hotpepperApiRetryCount = 3;
-  static const int hotpepperMaxResults = 100;
+  // HotPepper API 設定 - ApiConfigから取得
+  static int get hotpepperApiTimeout => ApiConfig.hotpepperApiTimeout;
+  static int get hotpepperApiRetryCount => ApiConfig.hotpepperApiRetryCount;
+  static int get hotpepperMaxResults => ApiConfig.hotpepperMaxResults;
 
-  // Google Maps 設定
-  static const double defaultMapZoom = 15.0;
-  static const double defaultLocationRadius = 1000.0; // メートル
+  // Google Maps 設定 - UiConfigから取得
+  static double get defaultMapZoom => UiConfig.defaultMapZoom;
+  static double get defaultLocationRadius =>
+      UiConfig.defaultMapZoom * 100; // 概算値
 
-  // アプリ設定
+  // アプリ設定 - 固定値（変更頻度が低いため）
   static const int maxPhotoFileSize = 5 * 1024 * 1024; // 5MB
   static const List<String> supportedImageExtensions = [
     '.jpg',
@@ -50,7 +56,20 @@ class AppConstants {
     '.png'
   ];
 
-  // キャッシュ設定
+  // キャッシュ設定 - 固定値（変更頻度が低いため）
   static const int cacheExpirationHours = 24;
   static const int maxCacheEntries = 1000;
+
+  /// 非推奨警告
+  @Deprecated(
+      'AppConstants の使用は非推奨です。代わりに分野別設定クラス（ApiConfig、UiConfig等）を使用してください。')
+  static void showDeprecationWarning() {
+    // 開発環境でのみ警告を表示
+    if (ConfigManager.isDevelopment) {
+      developer.log(
+        'Warning: AppConstants is deprecated. Use domain-specific config classes instead.',
+        name: 'AppConstants',
+      );
+    }
+  }
 }

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 import '../config/api_config.dart';
 import '../config/config_manager.dart';
 import '../config/database_config.dart';
+import '../config/location_config.dart';
 import '../config/ui_config.dart';
 
 /// アプリケーション定数クラス
@@ -45,8 +46,10 @@ class AppConstants {
 
   // Google Maps 設定 - UiConfigから取得
   static double get defaultMapZoom => UiConfig.defaultMapZoom;
+
+  // 位置情報設定 - LocationConfigから取得
   static double get defaultLocationRadius =>
-      UiConfig.defaultMapZoom * 100; // 概算値
+      LocationConfig.defaultLocationRadius;
 
   // アプリ設定 - 固定値（変更頻度が低いため）
   static const int maxPhotoFileSize = 5 * 1024 * 1024; // 5MB
@@ -64,8 +67,8 @@ class AppConstants {
   @Deprecated(
       'AppConstants の使用は非推奨です。代わりに分野別設定クラス（ApiConfig、UiConfig等）を使用してください。')
   static void showDeprecationWarning() {
-    // 開発環境でのみ警告を表示
-    if (ConfigManager.isDevelopment) {
+    // 開発環境でのみ警告を表示（環境変数から直接取得して循環依存を回避）
+    if (const bool.fromEnvironment('DEVELOPMENT', defaultValue: true)) {
       developer.log(
         'Warning: AppConstants is deprecated. Use domain-specific config classes instead.',
         name: 'AppConstants',

--- a/lib/data/datasources/hotpepper_api_datasource.dart
+++ b/lib/data/datasources/hotpepper_api_datasource.dart
@@ -1,4 +1,4 @@
-import '../../core/constants/app_constants.dart';
+import '../../core/config/api_config.dart';
 import '../../core/config/config_manager.dart';
 import '../../core/network/base_api_service.dart';
 import '../../core/exceptions/domain_exceptions.dart';
@@ -70,13 +70,11 @@ class HotpepperApiDatasourceImpl extends BaseApiService
     try {
       // 新しいHTTPシステムを使用してAPIリクエスト実行
       return await getAndParse<HotpepperSearchResponse>(
-        AppConstants.hotpepperApiUrl,
+        ApiConfig.hotpepperApiUrl,
         (json) =>
             HotpepperSearchResponse.fromJson(json as Map<String, dynamic>),
         queryParameters: queryParams,
-        headers: {
-          'User-Agent': 'MachiApp/1.0.0',
-        },
+        headers: ApiConfig.commonHeaders,
       );
     } on NetworkException catch (e) {
       // 特定のHTTPステータスコードに基づいて適切なエラーメッセージを提供

--- a/lib/data/services/geolocator_location_service.dart
+++ b/lib/data/services/geolocator_location_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:developer' as developer;
 import 'package:geolocator/geolocator.dart';
+import '../../core/config/location_config.dart';
 import '../../domain/entities/location.dart';
 import '../../domain/services/location_service.dart';
 
@@ -13,8 +14,8 @@ class GeolocatorLocationService implements LocationService {
   final LocationAccuracy accuracy;
 
   const GeolocatorLocationService({
-    this.timeoutSeconds = 10,
-    this.accuracy = LocationAccuracy.high,
+    this.timeoutSeconds = LocationConfig.defaultTimeoutSeconds,
+    this.accuracy = LocationConfig.defaultAccuracy,
   });
   @override
   Future<Location> getCurrentLocation() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ Future<void> main() async {
       final validationResults = ConfigManager.validateAllConfigs();
       final hasErrors =
           validationResults.values.any((errors) => errors.isNotEmpty);
+      final hasCriticalErrors = ConfigManager.hasAnyCriticalErrors;
 
       if (hasErrors) {
         debugPrint('設定検証でエラーが検出されました:');
@@ -40,6 +41,15 @@ Future<void> main() async {
             debugPrint('  $domain: ${errors.join(', ')}');
           }
         });
+
+        // Criticalエラーがある場合はアプリ起動を停止
+        if (hasCriticalErrors) {
+          debugPrint('Critical設定エラーが検出されました。アプリを安全に起動できません。');
+          throw Exception(
+              'Critical configuration errors detected. Application cannot start safely.');
+        } else {
+          debugPrint('Non-critical設定エラーのため、アプリは制限付きモードで起動します。');
+        }
       } else {
         debugPrint('すべての設定検証が完了しました');
       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,22 @@ Future<void> main() async {
         enableDebugLogging: true,
       );
       debugPrint('設定管理の初期化が完了しました: ${ConfigManager.debugString}');
+
+      // 統合設定検証を実行
+      final validationResults = ConfigManager.validateAllConfigs();
+      final hasErrors =
+          validationResults.values.any((errors) => errors.isNotEmpty);
+
+      if (hasErrors) {
+        debugPrint('設定検証でエラーが検出されました:');
+        validationResults.forEach((domain, errors) {
+          if (errors.isNotEmpty) {
+            debugPrint('  $domain: ${errors.join(', ')}');
+          }
+        });
+      } else {
+        debugPrint('すべての設定検証が完了しました');
+      }
     } catch (e) {
       debugPrint('設定管理の初期化でエラーが発生しました: $e');
       debugPrint('アプリは制限付きモードで起動します');

--- a/test/unit/core/config/api_config_test.dart
+++ b/test/unit/core/config/api_config_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/api_config.dart';
+
+void main() {
+  group('ApiConfig Tests', () {
+    test('should have correct default values', () {
+      expect(ApiConfig.hotpepperApiUrl,
+          'https://webservice.recruit.co.jp/hotpepper/gourmet/v1/');
+      expect(ApiConfig.hotpepperApiTimeout, 10);
+      expect(ApiConfig.hotpepperApiRetryCount, 3);
+      expect(ApiConfig.hotpepperMaxResults, 100);
+      expect(ApiConfig.hotpepperRateLimit, 5);
+      expect(ApiConfig.hotpepperDailyLimit, 3000);
+      expect(ApiConfig.googleMapsApiTimeout, 15);
+      expect(ApiConfig.googleMapsApiRetryCount, 2);
+      expect(ApiConfig.userAgent, 'MachiApp/1.0.0');
+    });
+
+    test('should validate timeout values correctly', () {
+      expect(ApiConfig.isValidTimeout(1), true);
+      expect(ApiConfig.isValidTimeout(30), true);
+      expect(ApiConfig.isValidTimeout(60), true);
+      expect(ApiConfig.isValidTimeout(0), false);
+      expect(ApiConfig.isValidTimeout(-1), false);
+      expect(ApiConfig.isValidTimeout(61), false);
+    });
+
+    test('should validate retry count values correctly', () {
+      expect(ApiConfig.isValidRetryCount(0), true);
+      expect(ApiConfig.isValidRetryCount(3), true);
+      expect(ApiConfig.isValidRetryCount(5), true);
+      expect(ApiConfig.isValidRetryCount(-1), false);
+      expect(ApiConfig.isValidRetryCount(6), false);
+    });
+
+    test('should validate max results values correctly', () {
+      expect(ApiConfig.isValidMaxResults(1), true);
+      expect(ApiConfig.isValidMaxResults(50), true);
+      expect(ApiConfig.isValidMaxResults(100), true);
+      expect(ApiConfig.isValidMaxResults(0), false);
+      expect(ApiConfig.isValidMaxResults(-1), false);
+      expect(ApiConfig.isValidMaxResults(101), false);
+    });
+
+    test('should provide comprehensive debug info', () {
+      final debugInfo = ApiConfig.debugInfo;
+
+      expect(debugInfo, isA<Map<String, dynamic>>());
+      expect(debugInfo['hotpepperApiUrl'], isNotEmpty);
+      expect(debugInfo['hotpepperApiTimeout'], isA<int>());
+      expect(debugInfo['hotpepperApiRetryCount'], isA<int>());
+      expect(debugInfo['hotpepperMaxResults'], isA<int>());
+      expect(debugInfo['hotpepperRateLimit'], isA<int>());
+      expect(debugInfo['hotpepperDailyLimit'], isA<int>());
+      expect(debugInfo['googleMapsApiUrl'], isNotEmpty);
+      expect(debugInfo['googleMapsApiTimeout'], isA<int>());
+      expect(debugInfo['googleMapsApiRetryCount'], isA<int>());
+      expect(debugInfo['userAgent'], isNotEmpty);
+    });
+
+    test('should have correct common headers', () {
+      final headers = ApiConfig.commonHeaders;
+
+      expect(headers['User-Agent'], 'MachiApp/1.0.0');
+      expect(headers['Accept'], 'application/json');
+      expect(headers['Content-Type'], 'application/json');
+    });
+
+    test('should validate boundary values correctly', () {
+      // Timeout boundary tests
+      expect(ApiConfig.isValidTimeout(1), true); // min
+      expect(ApiConfig.isValidTimeout(60), true); // max
+      expect(ApiConfig.isValidTimeout(0), false); // below min
+      expect(ApiConfig.isValidTimeout(61), false); // above max
+
+      // Retry count boundary tests
+      expect(ApiConfig.isValidRetryCount(0), true); // min
+      expect(ApiConfig.isValidRetryCount(5), true); // max
+      expect(ApiConfig.isValidRetryCount(-1), false); // below min
+      expect(ApiConfig.isValidRetryCount(6), false); // above max
+
+      // Max results boundary tests
+      expect(ApiConfig.isValidMaxResults(1), true); // min
+      expect(ApiConfig.isValidMaxResults(100), true); // max
+      expect(ApiConfig.isValidMaxResults(0), false); // below min
+      expect(ApiConfig.isValidMaxResults(101), false); // above max
+    });
+  });
+}

--- a/test/unit/core/config/database_config_test.dart
+++ b/test/unit/core/config/database_config_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/database_config.dart';
+
+void main() {
+  group('DatabaseConfig Tests', () {
+    test('should have correct default values', () {
+      expect(DatabaseConfig.databaseName, 'machiapp.db');
+      expect(DatabaseConfig.databaseVersion, 2);
+      expect(DatabaseConfig.databasePath, 'databases');
+      expect(DatabaseConfig.enableForeignKeys, true);
+      expect(DatabaseConfig.enableWalMode, true);
+      expect(DatabaseConfig.synchronousMode, 'NORMAL');
+      expect(DatabaseConfig.cacheSize, 1000);
+      expect(DatabaseConfig.pageSize, 4096);
+      expect(DatabaseConfig.transactionTimeout, 30);
+      expect(DatabaseConfig.maxTransactionRetries, 3);
+      expect(DatabaseConfig.enableAutoBackup, true);
+      expect(DatabaseConfig.backupInterval, 24);
+      expect(DatabaseConfig.maxBackupFiles, 7);
+      expect(DatabaseConfig.enableIntegrityCheck, true);
+      expect(DatabaseConfig.integrityCheckInterval, 7);
+      expect(DatabaseConfig.enableAutoVacuum, true);
+      expect(DatabaseConfig.vacuumInterval, 30);
+    });
+
+    test('should validate database version correctly', () {
+      expect(DatabaseConfig.isValidDatabaseVersion(1), true);
+      expect(DatabaseConfig.isValidDatabaseVersion(50), true);
+      expect(DatabaseConfig.isValidDatabaseVersion(100), true);
+      expect(DatabaseConfig.isValidDatabaseVersion(0), false);
+      expect(DatabaseConfig.isValidDatabaseVersion(-1), false);
+      expect(DatabaseConfig.isValidDatabaseVersion(101), false);
+    });
+
+    test('should validate cache size correctly', () {
+      expect(DatabaseConfig.isValidCacheSize(100), true);
+      expect(DatabaseConfig.isValidCacheSize(5000), true);
+      expect(DatabaseConfig.isValidCacheSize(10000), true);
+      expect(DatabaseConfig.isValidCacheSize(99), false);
+      expect(DatabaseConfig.isValidCacheSize(-1), false);
+      expect(DatabaseConfig.isValidCacheSize(10001), false);
+    });
+
+    test('should validate page size correctly', () {
+      expect(DatabaseConfig.isValidPageSize(1024), true);
+      expect(DatabaseConfig.isValidPageSize(2048), true);
+      expect(DatabaseConfig.isValidPageSize(4096), true);
+      expect(DatabaseConfig.isValidPageSize(8192), true);
+      expect(DatabaseConfig.isValidPageSize(16384), true);
+      expect(DatabaseConfig.isValidPageSize(32768), true);
+      expect(DatabaseConfig.isValidPageSize(65536), true);
+      expect(DatabaseConfig.isValidPageSize(512), false);
+      expect(DatabaseConfig.isValidPageSize(65537), false);
+    });
+
+    test('should validate transaction timeout correctly', () {
+      expect(DatabaseConfig.isValidTransactionTimeout(1), true);
+      expect(DatabaseConfig.isValidTransactionTimeout(150), true);
+      expect(DatabaseConfig.isValidTransactionTimeout(300), true);
+      expect(DatabaseConfig.isValidTransactionTimeout(0), false);
+      expect(DatabaseConfig.isValidTransactionTimeout(-1), false);
+      expect(DatabaseConfig.isValidTransactionTimeout(301), false);
+    });
+
+    test('should validate max retries correctly', () {
+      expect(DatabaseConfig.isValidMaxRetries(0), true);
+      expect(DatabaseConfig.isValidMaxRetries(5), true);
+      expect(DatabaseConfig.isValidMaxRetries(10), true);
+      expect(DatabaseConfig.isValidMaxRetries(-1), false);
+      expect(DatabaseConfig.isValidMaxRetries(11), false);
+    });
+
+    test('should validate interval correctly', () {
+      expect(DatabaseConfig.isValidInterval(1), true);
+      expect(DatabaseConfig.isValidInterval(84), true);
+      expect(DatabaseConfig.isValidInterval(168), true);
+      expect(DatabaseConfig.isValidInterval(0), false);
+      expect(DatabaseConfig.isValidInterval(-1), false);
+      expect(DatabaseConfig.isValidInterval(169), false);
+    });
+
+    test('should validate backup files correctly', () {
+      expect(DatabaseConfig.isValidBackupFiles(1), true);
+      expect(DatabaseConfig.isValidBackupFiles(15), true);
+      expect(DatabaseConfig.isValidBackupFiles(30), true);
+      expect(DatabaseConfig.isValidBackupFiles(0), false);
+      expect(DatabaseConfig.isValidBackupFiles(-1), false);
+      expect(DatabaseConfig.isValidBackupFiles(31), false);
+    });
+
+    test('should validate table name correctly', () {
+      expect(DatabaseConfig.isValidTableName('stores'), true);
+      expect(DatabaseConfig.isValidTableName('visit_records'), true);
+      expect(DatabaseConfig.isValidTableName('photos'), true);
+      expect(DatabaseConfig.isValidTableName('invalid_table'), false);
+    });
+
+    test('should validate index name correctly', () {
+      expect(DatabaseConfig.isValidIndexName('idx_stores_lat_lng'), true);
+      expect(DatabaseConfig.isValidIndexName('idx_stores_status'), true);
+      expect(
+          DatabaseConfig.isValidIndexName('idx_visit_records_store_id'), true);
+      expect(DatabaseConfig.isValidIndexName('idx_visit_records_visited_at'),
+          true);
+      expect(DatabaseConfig.isValidIndexName('idx_photos_store_id'), true);
+      expect(DatabaseConfig.isValidIndexName('idx_photos_visit_id'), true);
+      expect(DatabaseConfig.isValidIndexName('invalid_index'), false);
+    });
+
+    test('should validate synchronous mode correctly', () {
+      expect(DatabaseConfig.isValidSynchronousMode('OFF'), true);
+      expect(DatabaseConfig.isValidSynchronousMode('NORMAL'), true);
+      expect(DatabaseConfig.isValidSynchronousMode('FULL'), true);
+      expect(DatabaseConfig.isValidSynchronousMode('off'), true);
+      expect(DatabaseConfig.isValidSynchronousMode('normal'), true);
+      expect(DatabaseConfig.isValidSynchronousMode('full'), true);
+      expect(DatabaseConfig.isValidSynchronousMode('INVALID'), false);
+    });
+
+    test('should provide comprehensive debug info', () {
+      final debugInfo = DatabaseConfig.debugInfo;
+
+      expect(debugInfo, isA<Map<String, dynamic>>());
+      expect(debugInfo['databaseName'], isA<String>());
+      expect(debugInfo['databaseVersion'], isA<int>());
+      expect(debugInfo['databasePath'], isA<String>());
+      expect(debugInfo['tableNames'], isA<List>());
+      expect(debugInfo['enableForeignKeys'], isA<bool>());
+      expect(debugInfo['enableWalMode'], isA<bool>());
+      expect(debugInfo['synchronousMode'], isA<String>());
+      expect(debugInfo['cacheSize'], isA<int>());
+      expect(debugInfo['pageSize'], isA<int>());
+      expect(debugInfo['transactionTimeout'], isA<int>());
+      expect(debugInfo['maxTransactionRetries'], isA<int>());
+      expect(debugInfo['enableAutoBackup'], isA<bool>());
+      expect(debugInfo['backupInterval'], isA<int>());
+      expect(debugInfo['maxBackupFiles'], isA<int>());
+      expect(debugInfo['optimizedIndexes'], isA<List>());
+      expect(debugInfo['enableIntegrityCheck'], isA<bool>());
+      expect(debugInfo['integrityCheckInterval'], isA<int>());
+      expect(debugInfo['enableAutoVacuum'], isA<bool>());
+      expect(debugInfo['vacuumInterval'], isA<int>());
+    });
+
+    test('should have correct table names list', () {
+      final tableNames = DatabaseConfig.tableNames;
+
+      expect(tableNames, contains('stores'));
+      expect(tableNames, contains('visit_records'));
+      expect(tableNames, contains('photos'));
+      expect(tableNames.length, 3);
+    });
+
+    test('should have correct optimized indexes list', () {
+      final optimizedIndexes = DatabaseConfig.optimizedIndexes;
+
+      expect(optimizedIndexes, contains('idx_stores_lat_lng'));
+      expect(optimizedIndexes, contains('idx_stores_status'));
+      expect(optimizedIndexes, contains('idx_visit_records_store_id'));
+      expect(optimizedIndexes, contains('idx_visit_records_visited_at'));
+      expect(optimizedIndexes, contains('idx_photos_store_id'));
+      expect(optimizedIndexes, contains('idx_photos_visit_id'));
+      expect(optimizedIndexes.length, 6);
+    });
+
+    test('should have correct performance settings', () {
+      expect(DatabaseConfig.enableWalMode, true);
+      expect(DatabaseConfig.synchronousMode, 'NORMAL');
+      expect(DatabaseConfig.cacheSize, 1000);
+      expect(DatabaseConfig.pageSize, 4096);
+    });
+
+    test('should have correct backup settings', () {
+      expect(DatabaseConfig.enableAutoBackup, true);
+      expect(DatabaseConfig.backupInterval, 24);
+      expect(DatabaseConfig.maxBackupFiles, 7);
+    });
+
+    test('should have correct maintenance settings', () {
+      expect(DatabaseConfig.enableIntegrityCheck, true);
+      expect(DatabaseConfig.integrityCheckInterval, 7);
+      expect(DatabaseConfig.enableAutoVacuum, true);
+      expect(DatabaseConfig.vacuumInterval, 30);
+    });
+  });
+}

--- a/test/unit/core/config/location_config_test.dart
+++ b/test/unit/core/config/location_config_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:chinese_food_app/core/config/location_config.dart';
+
+void main() {
+  group('LocationConfig Tests', () {
+    test('should have correct default values', () {
+      expect(LocationConfig.defaultTimeoutSeconds, 10);
+      expect(LocationConfig.maxTimeoutSeconds, 60);
+      expect(LocationConfig.minTimeoutSeconds, 1);
+      expect(LocationConfig.defaultAccuracy, LocationAccuracy.high);
+      expect(LocationConfig.fallbackAccuracy, LocationAccuracy.medium);
+      expect(LocationConfig.defaultLocationRadius, 1000.0);
+      expect(LocationConfig.minLocationRadius, 100.0);
+      expect(LocationConfig.maxLocationRadius, 10000.0);
+      expect(LocationConfig.minAcceptableAccuracy, 100.0);
+      expect(LocationConfig.maxAcceptableAccuracy, 1000.0);
+      expect(LocationConfig.locationUpdateInterval, 30);
+      expect(LocationConfig.minUpdateInterval, 5);
+      expect(LocationConfig.maxUpdateInterval, 300);
+    });
+
+    test('should validate timeout values correctly', () {
+      expect(LocationConfig.isValidTimeout(1), true);
+      expect(LocationConfig.isValidTimeout(30), true);
+      expect(LocationConfig.isValidTimeout(60), true);
+      expect(LocationConfig.isValidTimeout(0), false);
+      expect(LocationConfig.isValidTimeout(-1), false);
+      expect(LocationConfig.isValidTimeout(61), false);
+    });
+
+    test('should validate radius values correctly', () {
+      expect(LocationConfig.isValidRadius(100.0), true);
+      expect(LocationConfig.isValidRadius(1000.0), true);
+      expect(LocationConfig.isValidRadius(10000.0), true);
+      expect(LocationConfig.isValidRadius(99.9), false);
+      expect(LocationConfig.isValidRadius(-1.0), false);
+      expect(LocationConfig.isValidRadius(10000.1), false);
+    });
+
+    test('should validate accuracy values correctly', () {
+      expect(LocationConfig.isValidAccuracy(100.0), true);
+      expect(LocationConfig.isValidAccuracy(500.0), true);
+      expect(LocationConfig.isValidAccuracy(1000.0), true);
+      expect(LocationConfig.isValidAccuracy(99.9), false);
+      expect(LocationConfig.isValidAccuracy(-1.0), false);
+      expect(LocationConfig.isValidAccuracy(1000.1), false);
+    });
+
+    test('should validate update interval values correctly', () {
+      expect(LocationConfig.isValidUpdateInterval(5), true);
+      expect(LocationConfig.isValidUpdateInterval(30), true);
+      expect(LocationConfig.isValidUpdateInterval(300), true);
+      expect(LocationConfig.isValidUpdateInterval(4), false);
+      expect(LocationConfig.isValidUpdateInterval(-1), false);
+      expect(LocationConfig.isValidUpdateInterval(301), false);
+    });
+
+    test('should validate acceptable permissions correctly', () {
+      expect(
+          LocationConfig.isPermissionAcceptable(LocationPermission.whileInUse),
+          true);
+      expect(LocationConfig.isPermissionAcceptable(LocationPermission.always),
+          true);
+      expect(LocationConfig.isPermissionAcceptable(LocationPermission.denied),
+          false);
+      expect(
+          LocationConfig.isPermissionAcceptable(
+              LocationPermission.deniedForever),
+          false);
+      expect(
+          LocationConfig.isPermissionAcceptable(
+              LocationPermission.unableToDetermine),
+          false);
+    });
+
+    test('should get correct accuracy level from string', () {
+      expect(
+          LocationConfig.getAccuracyLevel('lowest'), LocationAccuracy.lowest);
+      expect(LocationConfig.getAccuracyLevel('low'), LocationAccuracy.low);
+      expect(
+          LocationConfig.getAccuracyLevel('medium'), LocationAccuracy.medium);
+      expect(LocationConfig.getAccuracyLevel('high'), LocationAccuracy.high);
+      expect(LocationConfig.getAccuracyLevel('best'), LocationAccuracy.best);
+      expect(LocationConfig.getAccuracyLevel('bestfornavigation'),
+          LocationAccuracy.bestForNavigation);
+      expect(LocationConfig.getAccuracyLevel('invalid'),
+          LocationConfig.defaultAccuracy);
+      expect(
+          LocationConfig.getAccuracyLevel(''), LocationConfig.defaultAccuracy);
+    });
+
+    test('should provide comprehensive debug info', () {
+      final debugInfo = LocationConfig.debugInfo;
+
+      expect(debugInfo, isA<Map<String, dynamic>>());
+      expect(debugInfo['defaultTimeoutSeconds'], isA<int>());
+      expect(debugInfo['maxTimeoutSeconds'], isA<int>());
+      expect(debugInfo['minTimeoutSeconds'], isA<int>());
+      expect(debugInfo['defaultAccuracy'], isA<String>());
+      expect(debugInfo['fallbackAccuracy'], isA<String>());
+      expect(debugInfo['acceptablePermissions'], isA<List>());
+      expect(debugInfo['defaultLocationRadius'], isA<double>());
+      expect(debugInfo['minLocationRadius'], isA<double>());
+      expect(debugInfo['maxLocationRadius'], isA<double>());
+      expect(debugInfo['minAcceptableAccuracy'], isA<double>());
+      expect(debugInfo['maxAcceptableAccuracy'], isA<double>());
+      expect(debugInfo['locationUpdateInterval'], isA<int>());
+      expect(debugInfo['minUpdateInterval'], isA<int>());
+      expect(debugInfo['maxUpdateInterval'], isA<int>());
+    });
+
+    test('should have acceptable permissions list', () {
+      final acceptablePermissions = LocationConfig.acceptablePermissions;
+
+      expect(acceptablePermissions, contains(LocationPermission.whileInUse));
+      expect(acceptablePermissions, contains(LocationPermission.always));
+      expect(acceptablePermissions, isNot(contains(LocationPermission.denied)));
+      expect(acceptablePermissions,
+          isNot(contains(LocationPermission.deniedForever)));
+      expect(acceptablePermissions,
+          isNot(contains(LocationPermission.unableToDetermine)));
+    });
+
+    test('should validate boundary values correctly', () {
+      // Timeout boundary tests
+      expect(LocationConfig.isValidTimeout(1), true); // min
+      expect(LocationConfig.isValidTimeout(60), true); // max
+      expect(LocationConfig.isValidTimeout(0), false); // below min
+      expect(LocationConfig.isValidTimeout(61), false); // above max
+
+      // Radius boundary tests
+      expect(LocationConfig.isValidRadius(100.0), true); // min
+      expect(LocationConfig.isValidRadius(10000.0), true); // max
+      expect(LocationConfig.isValidRadius(99.9), false); // below min
+      expect(LocationConfig.isValidRadius(10000.1), false); // above max
+
+      // Update interval boundary tests
+      expect(LocationConfig.isValidUpdateInterval(5), true); // min
+      expect(LocationConfig.isValidUpdateInterval(300), true); // max
+      expect(LocationConfig.isValidUpdateInterval(4), false); // below min
+      expect(LocationConfig.isValidUpdateInterval(301), false); // above max
+    });
+  });
+}

--- a/test/unit/core/config/search_config_test.dart
+++ b/test/unit/core/config/search_config_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/search_config.dart';
+
+void main() {
+  group('SearchConfig Tests', () {
+    test('should have correct default values', () {
+      expect(SearchConfig.defaultKeyword, '中華');
+      expect(SearchConfig.defaultRange, 3);
+      expect(SearchConfig.defaultCount, 20);
+      expect(SearchConfig.defaultStart, 1);
+      expect(SearchConfig.minCount, 1);
+      expect(SearchConfig.maxCount, 100);
+      expect(SearchConfig.defaultPageSize, 20);
+      expect(SearchConfig.minStart, 1);
+      expect(SearchConfig.maxStart, 1000);
+    });
+
+    test('should validate range values correctly', () {
+      expect(SearchConfig.isValidRange(1), true);
+      expect(SearchConfig.isValidRange(3), true);
+      expect(SearchConfig.isValidRange(5), true);
+      expect(SearchConfig.isValidRange(0), false);
+      expect(SearchConfig.isValidRange(6), false);
+      expect(SearchConfig.isValidRange(-1), false);
+    });
+
+    test('should validate count values correctly', () {
+      expect(SearchConfig.isValidCount(1), true);
+      expect(SearchConfig.isValidCount(50), true);
+      expect(SearchConfig.isValidCount(100), true);
+      expect(SearchConfig.isValidCount(0), false);
+      expect(SearchConfig.isValidCount(-1), false);
+      expect(SearchConfig.isValidCount(101), false);
+    });
+
+    test('should validate start values correctly', () {
+      expect(SearchConfig.isValidStart(1), true);
+      expect(SearchConfig.isValidStart(500), true);
+      expect(SearchConfig.isValidStart(1000), true);
+      expect(SearchConfig.isValidStart(0), false);
+      expect(SearchConfig.isValidStart(-1), false);
+      expect(SearchConfig.isValidStart(1001), false);
+    });
+
+    test('should validate keyword values correctly', () {
+      expect(SearchConfig.isValidKeyword('中華'), true);
+      expect(SearchConfig.isValidKeyword('ラーメン'), true);
+      expect(SearchConfig.isValidKeyword(''), false);
+      expect(SearchConfig.isValidKeyword('a' * 101), false);
+      expect(SearchConfig.isValidKeyword('a' * 100), true);
+    });
+
+    test('should validate allowed keywords correctly', () {
+      expect(SearchConfig.isAllowedKeyword('中華'), true);
+      expect(SearchConfig.isAllowedKeyword('中華料理'), true);
+      expect(SearchConfig.isAllowedKeyword('町中華'), true);
+      expect(SearchConfig.isAllowedKeyword('餃子'), true);
+      expect(SearchConfig.isAllowedKeyword('ラーメン'), true);
+      expect(SearchConfig.isAllowedKeyword('炒飯'), true);
+      expect(SearchConfig.isAllowedKeyword('炒め物'), true);
+      expect(SearchConfig.isAllowedKeyword('麺類'), true);
+      expect(SearchConfig.isAllowedKeyword('定食'), true);
+      expect(SearchConfig.isAllowedKeyword('イタリアン'), false);
+      expect(SearchConfig.isAllowedKeyword('フレンチ'), false);
+    });
+
+    test('should convert range to meters correctly', () {
+      expect(SearchConfig.rangeToMeter(1), 300);
+      expect(SearchConfig.rangeToMeter(2), 500);
+      expect(SearchConfig.rangeToMeter(3), 1000);
+      expect(SearchConfig.rangeToMeter(4), 2000);
+      expect(SearchConfig.rangeToMeter(5), 3000);
+      expect(SearchConfig.rangeToMeter(6), null);
+      expect(SearchConfig.rangeToMeter(0), null);
+    });
+
+    test('should convert meter to range correctly', () {
+      expect(SearchConfig.meterToRange(300), 1);
+      expect(SearchConfig.meterToRange(500), 2);
+      expect(SearchConfig.meterToRange(1000), 3);
+      expect(SearchConfig.meterToRange(2000), 4);
+      expect(SearchConfig.meterToRange(3000), 5);
+      expect(SearchConfig.meterToRange(1500), null);
+      expect(SearchConfig.meterToRange(100), null);
+    });
+
+    test('should validate budget range correctly', () {
+      expect(SearchConfig.isValidBudgetRange('～500円'), true);
+      expect(SearchConfig.isValidBudgetRange('501～1000円'), true);
+      expect(SearchConfig.isValidBudgetRange('1001～1500円'), true);
+      expect(SearchConfig.isValidBudgetRange('1501～2000円'), true);
+      expect(SearchConfig.isValidBudgetRange('2001～3000円'), true);
+      expect(SearchConfig.isValidBudgetRange('3001～4000円'), true);
+      expect(SearchConfig.isValidBudgetRange('4001～5000円'), true);
+      expect(SearchConfig.isValidBudgetRange('5001円～'), true);
+      expect(SearchConfig.isValidBudgetRange('無効な範囲'), false);
+    });
+
+    test('should validate sort option correctly', () {
+      expect(SearchConfig.isValidSortOption('distance'), true);
+      expect(SearchConfig.isValidSortOption('rating'), true);
+      expect(SearchConfig.isValidSortOption('budget'), true);
+      expect(SearchConfig.isValidSortOption('name'), true);
+      expect(SearchConfig.isValidSortOption('invalid'), false);
+    });
+
+    test('should provide comprehensive debug info', () {
+      final debugInfo = SearchConfig.debugInfo;
+
+      expect(debugInfo, isA<Map<String, dynamic>>());
+      expect(debugInfo['defaultKeyword'], isA<String>());
+      expect(debugInfo['defaultRange'], isA<int>());
+      expect(debugInfo['defaultCount'], isA<int>());
+      expect(debugInfo['defaultStart'], isA<int>());
+      expect(debugInfo['rangeToMeters'], isA<Map>());
+      expect(debugInfo['allowedKeywords'], isA<List>());
+      expect(debugInfo['budgetRanges'], isA<List>());
+      expect(debugInfo['sortOptions'], isA<List>());
+    });
+
+    test('should have correct range to meters mapping', () {
+      final rangeToMeters = SearchConfig.rangeToMeters;
+
+      expect(rangeToMeters[1], 300);
+      expect(rangeToMeters[2], 500);
+      expect(rangeToMeters[3], 1000);
+      expect(rangeToMeters[4], 2000);
+      expect(rangeToMeters[5], 3000);
+      expect(rangeToMeters.length, 5);
+    });
+
+    test('should have correct allowed keywords list', () {
+      final allowedKeywords = SearchConfig.allowedKeywords;
+
+      expect(allowedKeywords, contains('中華'));
+      expect(allowedKeywords, contains('中華料理'));
+      expect(allowedKeywords, contains('町中華'));
+      expect(allowedKeywords, contains('餃子'));
+      expect(allowedKeywords, contains('ラーメン'));
+      expect(allowedKeywords, contains('炒飯'));
+      expect(allowedKeywords, contains('炒め物'));
+      expect(allowedKeywords, contains('麺類'));
+      expect(allowedKeywords, contains('定食'));
+    });
+
+    test('should have correct budget ranges list', () {
+      final budgetRanges = SearchConfig.budgetRanges;
+
+      expect(budgetRanges, contains('～500円'));
+      expect(budgetRanges, contains('501～1000円'));
+      expect(budgetRanges, contains('1001～1500円'));
+      expect(budgetRanges, contains('1501～2000円'));
+      expect(budgetRanges, contains('2001～3000円'));
+      expect(budgetRanges, contains('3001～4000円'));
+      expect(budgetRanges, contains('4001～5000円'));
+      expect(budgetRanges, contains('5001円～'));
+    });
+
+    test('should have correct sort options list', () {
+      final sortOptions = SearchConfig.sortOptions;
+
+      expect(sortOptions, contains('distance'));
+      expect(sortOptions, contains('rating'));
+      expect(sortOptions, contains('budget'));
+      expect(sortOptions, contains('name'));
+    });
+  });
+}

--- a/test/unit/core/config/ui_config_test.dart
+++ b/test/unit/core/config/ui_config_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/ui_config.dart';
+
+void main() {
+  group('UiConfig Tests', () {
+    test('should have correct default values', () {
+      expect(UiConfig.appName, 'マチアプ');
+      expect(UiConfig.appVersion, '1.0.0');
+      expect(UiConfig.appDescription, '町中華探索アプリ');
+      expect(UiConfig.cardBorderRadius, 12.0);
+      expect(UiConfig.defaultPadding, 16.0);
+      expect(UiConfig.smallPadding, 8.0);
+      expect(UiConfig.largePadding, 24.0);
+      expect(UiConfig.extraLargePadding, 32.0);
+      expect(UiConfig.defaultMapZoom, 15.0);
+      expect(UiConfig.minMapZoom, 10.0);
+      expect(UiConfig.maxMapZoom, 20.0);
+    });
+
+    test('should validate padding values correctly', () {
+      expect(UiConfig.isValidPadding(0), true);
+      expect(UiConfig.isValidPadding(50), true);
+      expect(UiConfig.isValidPadding(100), true);
+      expect(UiConfig.isValidPadding(-1), false);
+      expect(UiConfig.isValidPadding(101), false);
+    });
+
+    test('should validate border radius values correctly', () {
+      expect(UiConfig.isValidBorderRadius(0), true);
+      expect(UiConfig.isValidBorderRadius(25), true);
+      expect(UiConfig.isValidBorderRadius(50), true);
+      expect(UiConfig.isValidBorderRadius(-1), false);
+      expect(UiConfig.isValidBorderRadius(51), false);
+    });
+
+    test('should validate font size values correctly', () {
+      expect(UiConfig.isValidFontSize(8), true);
+      expect(UiConfig.isValidFontSize(36), true);
+      expect(UiConfig.isValidFontSize(72), true);
+      expect(UiConfig.isValidFontSize(7), false);
+      expect(UiConfig.isValidFontSize(73), false);
+    });
+
+    test('should validate icon size values correctly', () {
+      expect(UiConfig.isValidIconSize(12), true);
+      expect(UiConfig.isValidIconSize(50), true);
+      expect(UiConfig.isValidIconSize(100), true);
+      expect(UiConfig.isValidIconSize(11), false);
+      expect(UiConfig.isValidIconSize(101), false);
+    });
+
+    test('should validate image size values correctly', () {
+      expect(UiConfig.isValidImageSize(20), true);
+      expect(UiConfig.isValidImageSize(250), true);
+      expect(UiConfig.isValidImageSize(500), true);
+      expect(UiConfig.isValidImageSize(19), false);
+      expect(UiConfig.isValidImageSize(501), false);
+    });
+
+    test('should validate animation duration values correctly', () {
+      expect(
+          UiConfig.isValidAnimationDuration(Duration(milliseconds: 50)), true);
+      expect(UiConfig.isValidAnimationDuration(Duration(milliseconds: 2500)),
+          true);
+      expect(UiConfig.isValidAnimationDuration(Duration(milliseconds: 5000)),
+          true);
+      expect(
+          UiConfig.isValidAnimationDuration(Duration(milliseconds: 49)), false);
+      expect(UiConfig.isValidAnimationDuration(Duration(milliseconds: 5001)),
+          false);
+    });
+
+    test('should validate swipe threshold values correctly', () {
+      expect(UiConfig.isValidSwipeThreshold(0.1), true);
+      expect(UiConfig.isValidSwipeThreshold(0.5), true);
+      expect(UiConfig.isValidSwipeThreshold(1.0), true);
+      expect(UiConfig.isValidSwipeThreshold(0.09), false);
+      expect(UiConfig.isValidSwipeThreshold(1.1), false);
+    });
+
+    test('should validate map zoom values correctly', () {
+      expect(UiConfig.isValidMapZoom(10.0), true);
+      expect(UiConfig.isValidMapZoom(15.0), true);
+      expect(UiConfig.isValidMapZoom(20.0), true);
+      expect(UiConfig.isValidMapZoom(9.9), false);
+      expect(UiConfig.isValidMapZoom(20.1), false);
+    });
+
+    test('should provide comprehensive debug info', () {
+      final debugInfo = UiConfig.debugInfo;
+
+      expect(debugInfo, isA<Map<String, dynamic>>());
+      expect(debugInfo['appName'], isA<String>());
+      expect(debugInfo['appVersion'], isA<String>());
+      expect(debugInfo['appDescription'], isA<String>());
+      expect(debugInfo['cardBorderRadius'], isA<double>());
+      expect(debugInfo['defaultPadding'], isA<double>());
+      expect(debugInfo['titleFontSize'], isA<double>());
+      expect(debugInfo['defaultIconSize'], isA<double>());
+      expect(debugInfo['defaultImageSize'], isA<double>());
+      expect(debugInfo['defaultAnimationDuration'], isA<int>());
+      expect(debugInfo['swipeThreshold'], isA<double>());
+      expect(debugInfo['primaryColor'], isA<String>());
+      expect(debugInfo['defaultMapZoom'], isA<double>());
+    });
+
+    test('should have correct color types', () {
+      expect(UiConfig.primaryColor, isA<Color>());
+      expect(UiConfig.secondaryColor, isA<Color>());
+      expect(UiConfig.errorColor, isA<Color>());
+      expect(UiConfig.successColor, isA<Color>());
+      expect(UiConfig.warningColor, isA<Color>());
+      expect(UiConfig.backgroundColor, isA<Color>());
+      expect(UiConfig.cardBackgroundColor, isA<Color>());
+      expect(UiConfig.textColor, isA<Color>());
+      expect(UiConfig.subtitleColor, isA<Color>());
+      expect(UiConfig.dividerColor, isA<Color>());
+    });
+
+    test('should have correct animation durations', () {
+      expect(UiConfig.defaultAnimationDuration, Duration(milliseconds: 300));
+      expect(UiConfig.quickAnimationDuration, Duration(milliseconds: 150));
+      expect(UiConfig.slowAnimationDuration, Duration(milliseconds: 500));
+    });
+
+    test('should have correct size values', () {
+      expect(UiConfig.titleFontSize, 24.0);
+      expect(UiConfig.subtitleFontSize, 18.0);
+      expect(UiConfig.bodyFontSize, 16.0);
+      expect(UiConfig.captionFontSize, 12.0);
+      expect(UiConfig.defaultIconSize, 24.0);
+      expect(UiConfig.smallIconSize, 16.0);
+      expect(UiConfig.largeIconSize, 32.0);
+    });
+
+    test('should have correct layout values', () {
+      expect(UiConfig.defaultMargin, 16.0);
+      expect(UiConfig.smallMargin, 8.0);
+      expect(UiConfig.largeMargin, 24.0);
+      expect(UiConfig.cardElevation, 4.0);
+      expect(UiConfig.cardMaxWidth, 400.0);
+      expect(UiConfig.cardMinHeight, 200.0);
+    });
+
+    test('should have correct button values', () {
+      expect(UiConfig.buttonHeight, 48.0);
+      expect(UiConfig.buttonBorderRadius, 8.0);
+      expect(UiConfig.iconButtonSize, 24.0);
+    });
+
+    test('should have correct swipe values', () {
+      expect(UiConfig.swipeThreshold, 0.3);
+      expect(UiConfig.swipeVelocityThreshold, 500.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Issue #55 の設定管理の集約化を実装しました。

### 🎯 実装内容
- **分野別設定クラスの新規作成**
  - `ApiConfig`: API関連設定の管理
  - `LocationConfig`: 位置情報関連設定の管理
  - `SearchConfig`: 検索関連設定の管理
  - `UiConfig`: UI関連設定の管理
  - `DatabaseConfig`: データベース関連設定の管理

- **統合設定管理システムの強化**
  - ConfigManagerに分野別設定アクセス機能を追加
  - 全設定の統合検証機能を追加
  - 設定の依存関係と影響範囲を明確化

- **設定検証機能の拡張**
  - ConfigValidatorに分野別設定検証機能を追加
  - 設定値の妥当性チェック機能を強化
  - 詳細な検証レポート機能を追加

- **既存コードの移行**
  - AppConstantsを分野別設定クラスに移行（後方互換性維持）
  - HotPepperApiDatasourceとGeolocatorLocationServiceを新設定システムに対応
  - main.dartに統合設定検証機能を追加

### 🔧 改善された課題
- ✅ 設定値の分散 → 分野別クラスで一元管理
- ✅ 影響範囲の不明確さ → 設定変更時の影響が明確に
- ✅ デフォルト値の不統一 → 統一された管理方法
- ✅ 設定の依存関係 → 関係性が明確に定義

### 🧪 テスト状況
- 全テスト（112個）がパス
- 静的解析エラーなし
- コードフォーマット完了

### 📚 技術仕様
- Clean Architecture原則に準拠
- 型安全な設定アクセス
- 環境別設定対応
- 包括的な設定検証

resolves #55

🤖 Generated with [Claude Code](https://claude.ai/code)