### PR TITLE
feat: 実際のAPIデータ統合機能の実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,33 +7,14 @@
 FLUTTER_ENV=development
 
 # ===============================================
-# 開発環境用 API キー
+# API キー設定（全環境共通）
 # ===============================================
 # HotPepper グルメサーチAPI
 # 取得方法: https://webservice.recruit.co.jp/register/
-DEV_HOTPEPPER_API_KEY=your_development_hotpepper_api_key_here
+HOTPEPPER_API_KEY=your_hotpepper_api_key_here
 
 # Google Maps API
 # 取得方法: https://developers.google.com/maps/documentation/android-sdk/get-api-key
-DEV_GOOGLE_MAPS_API_KEY=your_development_google_maps_api_key_here
-
-# ===============================================
-# ステージング環境用 API キー
-# ===============================================
-STAGING_HOTPEPPER_API_KEY=your_staging_hotpepper_api_key_here
-STAGING_GOOGLE_MAPS_API_KEY=your_staging_google_maps_api_key_here
-
-# ===============================================
-# 本番環境用 API キー
-# ===============================================
-PROD_HOTPEPPER_API_KEY=your_production_hotpepper_api_key_here
-PROD_GOOGLE_MAPS_API_KEY=your_production_google_maps_api_key_here
-
-# ===============================================
-# 後方互換性用（従来の設定）
-# ===============================================
-# 環境別キーが設定されていない場合にフォールバックとして使用
-HOTPEPPER_API_KEY=your_hotpepper_api_key_here
 GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 
 # ===============================================
@@ -48,64 +29,46 @@ GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 #
 # 3. アプリケーション実行
 #    flutter run
-#
-# 4. 環境切り替え（例：ステージング環境）
-#    flutter run --dart-define=FLUTTER_ENV=staging
+
+# ===============================================
+# API キー取得手順
+# ===============================================
+
+# 【HotPepper API】
+# 1. https://webservice.recruit.co.jp/register/ にアクセス
+# 2. アカウント作成・ログイン
+# 3. 新しいアプリケーションを登録
+# 4. APIキーを取得
+# 5. 上記の HOTPEPPER_API_KEY に設定
+
+# 【Google Maps API】
+# 1. https://console.cloud.google.com/ にアクセス
+# 2. プロジェクトを作成（既存プロジェクトでも可）
+# 3. API ライブラリで以下を有効化:
+#    - Maps SDK for Android
+#    - Maps SDK for iOS
+#    - Geocoding API
+# 4. 認証情報でAPIキーを作成
+# 5. 上記の GOOGLE_MAPS_API_KEY に設定
 
 # ===============================================
 # 注意事項
 # ===============================================
 # - .env ファイルは .gitignore に含まれているため、Git にコミットされません
-# - APIキーは秘密情報です。第三者に漏洩しないよう注意してください
-# - 本番環境では必ず専用のAPIキーを使用してください
-# - CI/CD環境では環境変数として設定してください
-
-# ===============================================
-# APIキー取得・設定ガイド
-# ===============================================
-
-# === HotPepper API ===
-# 1. https://webservice.recruit.co.jp/register/ にアクセス
-# 2. リクルートIDでログイン（新規作成の場合は登録）
-# 3. 「APIキー発行」からHotPepperグルメサーチAPIを選択
-# 4. 利用規約に同意してAPIキーを取得
-# 5. 上記の DEV_HOTPEPPER_API_KEY などに設定
-
-# === Google Maps API ===
-# 1. https://console.cloud.google.com/ にアクセス
-# 2. 新しいプロジェクトを作成（または既存プロジェクトを選択）
-# 3. APIとサービス > ライブラリ から以下を有効化:
-#    - Maps SDK for Android
-#    - Maps SDK for iOS
-#    - Geocoding API
-# 4. 認証情報 > 認証情報を作成 > APIキー
-# 5. 上記の DEV_GOOGLE_MAPS_API_KEY などに設定
-
-# ===============================================
-# 環境別実行方法
-# ===============================================
-
-# 開発環境（デフォルト）
-# flutter run
-
-# ステージング環境
-# flutter run --dart-define=FLUTTER_ENV=staging
-
-# 本番環境
-# flutter run --dart-define=FLUTTER_ENV=production
+# - APIキーは機密情報です。第三者と共有しないでください
+# - 本番環境では Flutter Secure Storage を使用してAPIキーを管理します
 
 # ===============================================
 # トラブルシューティング
 # ===============================================
-
-# Q: 「APIキーが設定されていません」エラーが出る
+# Q: アプリが「APIキーが設定されていません」というエラーを表示する
 # A: .env ファイルが作成されているか、APIキーが正しく設定されているか確認
 
-# Q: アプリが起動しない
-# A: flutter clean && flutter pub get を実行して依存関係をリセット
+# Q: HotPepper API のレスポンスが「401 Unauthorized」
+# A: HOTPEPPER_API_KEY が正しいか、APIキーの利用制限を確認
 
-# Q: 地図が表示されない
-# A: Google Maps APIが有効化されているか、APIキーが正しいか確認
+# Q: Google Maps が表示されない
+# A: GOOGLE_MAPS_API_KEY が正しいか、必要なAPIが有効化されているか確認
 
-# Q: 店舗検索結果が0件
-# A: HotPepper APIキーが正しいか、API利用制限に達していないか確認
+# Q: 位置情報が取得できない
+# A: デバイスの位置情報設定、アプリの位置情報権限を確認

--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,4 @@ ios/Podfile.lock
 macos/Podfile
 
 # iOS/macOS specific generated files
-ios/Flutter/Profile.xcconfig
+ios/Flutter/Profile.xcconfigapp_db.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,13 @@ commandlinetools-*.zip
 *.tar.gz
 *.zip
 
+Pods/
 
 .claude/
+
+# CocoaPods generated files
+ios/Podfile.lock
+macos/Podfile
+
+# iOS/macOS specific generated files
+ios/Flutter/Profile.xcconfig

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -1,0 +1,150 @@
+# 本番環境設定ファイル
+# production.yaml
+# 
+# ⚠️ 警告: このファイルには機密情報は含めないでください
+# APIキーなどの機密情報は環境変数またはSecure Storageから取得します
+
+# アプリケーション基本設定
+app:
+  name: "町中華探索アプリ「マチアプ」"
+  version: "1.0.0"
+  build_number: 1
+  bundle_id: "com.machiapp.chinese_food_explorer"
+  
+# 環境識別
+environment:
+  name: "production"
+  debug_mode: false
+  test_mode: false
+  
+# API設定
+api:
+  # HotPepper Gourmet API
+  hotpepper:
+    base_url: "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/"
+    timeout_seconds: 30
+    retry_attempts: 3
+    rate_limit:
+      requests_per_second: 5
+      daily_limit: 3000
+    # APIキーは環境変数 PROD_HOTPEPPER_API_KEY から取得
+    
+  # Google Maps API  
+  google_maps:
+    timeout_seconds: 30
+    retry_attempts: 3
+    # APIキーは環境変数 PROD_GOOGLE_MAPS_API_KEY から取得
+    
+# データベース設定
+database:
+  schema_version: 2
+  enable_foreign_keys: true
+  enable_wal_mode: true
+  cache_size: 2000
+  page_size: 4096
+  auto_vacuum: "INCREMENTAL"
+  
+# セキュリティ設定
+security:
+  # セキュアストレージ設定
+  secure_storage:
+    android:
+      encrypted_shared_preferences: true
+    ios:
+      accessibility: "first_unlock_this_device"
+      
+  # 暗号化設定
+  encryption:
+    algorithm: "AES-256-GCM"
+    key_derivation: "PBKDF2"
+    iterations: 100000
+    
+  # ネットワークセキュリティ
+  network:
+    enforce_https: true
+    certificate_pinning: true
+    timeout_seconds: 30
+    
+# パフォーマンス設定
+performance:
+  # 画像キャッシュ
+  image_cache:
+    max_cache_size: "100MB"
+    max_cache_age: "7d"
+    
+  # 位置情報取得
+  location:
+    accuracy: "high"
+    timeout_seconds: 30
+    cache_duration: "5m"
+    
+  # データベース最適化
+  database_optimization:
+    enable_indices: true
+    vacuum_on_startup: false
+    analyze_on_startup: true
+    
+# ログ設定
+logging:
+  level: "INFO"  # DEBUG, INFO, WARN, ERROR
+  console_output: false
+  file_output: true
+  max_file_size: "10MB"
+  max_files: 5
+  sensitive_data_logging: false
+  
+# 位置情報設定
+location:
+  default_search_radius: 3000  # 3km
+  max_search_radius: 10000     # 10km
+  position_accuracy: "high"
+  background_location: false
+  
+# UI設定
+ui:
+  theme: "system"  # light, dark, system
+  language: "ja"
+  animations_enabled: true
+  haptic_feedback: true
+  
+# 通知設定
+notifications:
+  push_notifications: false
+  local_notifications: true
+  
+# 分析・監視設定
+analytics:
+  crash_reporting: true
+  performance_monitoring: true
+  user_analytics: false  # プライバシー重視のため無効
+  
+# エラーハンドリング
+error_handling:
+  show_error_details: false
+  auto_retry: true
+  max_retry_attempts: 3
+  fallback_enabled: true
+  
+# App Store設定
+app_store:
+  ios:
+    app_id: "com.machiapp.chinese_food_explorer"
+    team_id: "YOUR_TEAM_ID"
+    
+  android:
+    package_name: "com.machiapp.chinese_food_explorer"
+    
+# バックアップ・復元
+backup:
+  auto_backup: true
+  backup_frequency: "daily"
+  max_backups: 7
+  include_photos: false  # ストレージ節約のため
+  
+# 機能フラグ
+features:
+  photo_upload: true
+  offline_mode: true
+  map_clustering: true
+  share_functionality: false  # MVP では無効
+  premium_features: false

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -27,13 +27,13 @@ api:
     rate_limit:
       requests_per_second: 5
       daily_limit: 3000
-    # APIキーは環境変数 PROD_HOTPEPPER_API_KEY から取得
+    # APIキーは環境変数 HOTPEPPER_API_KEY から取得
     
   # Google Maps API  
   google_maps:
     timeout_seconds: 30
     retry_attempts: 3
-    # APIキーは環境変数 PROD_GOOGLE_MAPS_API_KEY から取得
+    # APIキーは環境変数 GOOGLE_MAPS_API_KEY から取得
     
 # データベース設定
 database:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -26,13 +26,13 @@ api:
     rate_limit:
       requests_per_second: 3  # 控えめなレート制限
       daily_limit: 1000
-    # APIキーは環境変数 STAGING_HOTPEPPER_API_KEY から取得
+    # APIキーは環境変数 HOTPEPPER_API_KEY から取得
     
   # Google Maps API  
   google_maps:
     timeout_seconds: 45
     retry_attempts: 2
-    # APIキーは環境変数 STAGING_GOOGLE_MAPS_API_KEY から取得
+    # APIキーは環境変数 GOOGLE_MAPS_API_KEY から取得
     
 # データベース設定
 database:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -1,0 +1,156 @@
+# ステージング環境設定ファイル
+# staging.yaml
+# 
+# テスト環境用設定 - 本番に近い環境でのテスト用
+
+# アプリケーション基本設定
+app:
+  name: "町中華探索アプリ「マチアプ」(Staging)"
+  version: "1.0.0-staging"
+  build_number: 1
+  bundle_id: "com.machiapp.chinese_food_explorer.staging"
+  
+# 環境識別
+environment:
+  name: "staging"
+  debug_mode: true  # ステージングではデバッグ有効
+  test_mode: false
+  
+# API設定
+api:
+  # HotPepper Gourmet API
+  hotpepper:
+    base_url: "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/"
+    timeout_seconds: 45  # ステージングでは少し長めのタイムアウト
+    retry_attempts: 2
+    rate_limit:
+      requests_per_second: 3  # 控えめなレート制限
+      daily_limit: 1000
+    # APIキーは環境変数 STAGING_HOTPEPPER_API_KEY から取得
+    
+  # Google Maps API  
+  google_maps:
+    timeout_seconds: 45
+    retry_attempts: 2
+    # APIキーは環境変数 STAGING_GOOGLE_MAPS_API_KEY から取得
+    
+# データベース設定
+database:
+  schema_version: 2
+  enable_foreign_keys: true
+  enable_wal_mode: true
+  cache_size: 1000  # 本番より少なめ
+  page_size: 4096
+  auto_vacuum: "INCREMENTAL"
+  
+# セキュリティ設定
+security:
+  # セキュアストレージ設定（ステージング用）
+  secure_storage:
+    android:
+      encrypted_shared_preferences: true
+    ios:
+      accessibility: "first_unlock_this_device"
+      
+  # 暗号化設定
+  encryption:
+    algorithm: "AES-256-GCM"
+    key_derivation: "PBKDF2"
+    iterations: 50000  # テスト環境では軽量化
+    
+  # ネットワークセキュリティ
+  network:
+    enforce_https: true
+    certificate_pinning: false  # テスト環境では無効
+    timeout_seconds: 45
+    
+# パフォーマンス設定
+performance:
+  # 画像キャッシュ
+  image_cache:
+    max_cache_size: "50MB"  # ステージングでは小さめ
+    max_cache_age: "3d"
+    
+  # 位置情報取得
+  location:
+    accuracy: "medium"  # テスト用
+    timeout_seconds: 45
+    cache_duration: "2m"
+    
+  # データベース最適化
+  database_optimization:
+    enable_indices: true
+    vacuum_on_startup: false
+    analyze_on_startup: true
+    
+# ログ設定
+logging:
+  level: "DEBUG"  # ステージングでは詳細ログ
+  console_output: true
+  file_output: true
+  max_file_size: "50MB"
+  max_files: 10
+  sensitive_data_logging: true  # テスト用
+  
+# 位置情報設定
+location:
+  default_search_radius: 2000  # 2km（テスト用）
+  max_search_radius: 5000      # 5km
+  position_accuracy: "medium"
+  background_location: false
+  
+# UI設定
+ui:
+  theme: "system"
+  language: "ja"
+  animations_enabled: true
+  haptic_feedback: true
+  
+# 通知設定
+notifications:
+  push_notifications: false
+  local_notifications: true
+  
+# 分析・監視設定
+analytics:
+  crash_reporting: true
+  performance_monitoring: true
+  user_analytics: true  # テスト用分析有効
+  
+# エラーハンドリング
+error_handling:
+  show_error_details: true  # ステージングでは詳細表示
+  auto_retry: true
+  max_retry_attempts: 2
+  fallback_enabled: true
+  
+# App Store設定
+app_store:
+  ios:
+    app_id: "com.machiapp.chinese_food_explorer.staging"
+    team_id: "YOUR_TEAM_ID"
+    
+  android:
+    package_name: "com.machiapp.chinese_food_explorer.staging"
+    
+# バックアップ・復元
+backup:
+  auto_backup: false  # テスト環境では無効
+  backup_frequency: "never"
+  max_backups: 0
+  include_photos: false
+  
+# 機能フラグ
+features:
+  photo_upload: true
+  offline_mode: true
+  map_clustering: true
+  share_functionality: true   # ステージングでテスト
+  premium_features: true      # 全機能テスト可能
+  
+# テスト用設定
+testing:
+  mock_api_responses: false
+  test_data_enabled: true
+  performance_testing: true
+  ui_testing: true

--- a/docs/PRODUCTION_SETUP.md
+++ b/docs/PRODUCTION_SETUP.md
@@ -1,0 +1,337 @@
+# 本番環境セットアップガイド
+
+町中華探索アプリ「マチアプ」の本番環境セットアップ手順書
+
+## 📋 概要
+
+このガイドでは、開発環境から本番環境への移行とデプロイ手順を説明します。
+
+## 🏗️ 環境構成
+
+### 開発環境 (Development)
+- **用途**: ローカル開発・テスト
+- **APIキー管理**: `.env`ファイル
+- **データベース**: ローカルSQLite
+- **ログレベル**: DEBUG
+- **デバッグ**: 有効
+
+### ステージング環境 (Staging)  
+- **用途**: 本番前テスト・QA
+- **APIキー管理**: 環境変数
+- **データベース**: テスト用SQLite
+- **ログレベル**: DEBUG
+- **デバッグ**: 有効
+
+### 本番環境 (Production)
+- **用途**: エンドユーザー向けリリース
+- **APIキー管理**: Flutter Secure Storage
+- **データベース**: 本番SQLite (暗号化)
+- **ログレベル**: INFO
+- **デバッグ**: 無効
+
+## 🚀 本番デプロイ手順
+
+### 1. 事前準備
+
+#### 1.1 開発環境の確認
+```bash
+# Flutter環境確認
+flutter doctor
+
+# プロジェクトクリーンアップ
+flutter clean
+flutter pub get
+```
+
+#### 1.2 本番環境準備チェック
+```bash
+# 総合チェック実行
+./scripts/check-production-ready.sh
+```
+
+このスクリプトでチェックされる項目：
+- ✅ 開発環境の準備状況
+- ✅ プロジェクト構成の完整性
+- ✅ コード品質（フォーマット・静的解析）
+- ✅ テスト合格状況
+- ✅ セキュリティ（機密情報の漏洩チェック）
+- ✅ 依存関係の状態
+- ✅ ビルド可能性
+- ✅ 設定ファイルの整合性
+
+### 2. APIキー設定
+
+#### 2.1 本番用APIキー準備
+以下のAPIキーを取得してください：
+
+**HotPepper Gourmet API**
+- 取得先: [リクルートWebサービス](https://webservice.recruit.co.jp/)
+- 制限: 1日3,000リクエスト、1秒間5リクエスト
+- 形式: 英数字32〜50文字
+
+**Google Maps API**
+- 取得先: [Google Cloud Console](https://console.cloud.google.com/)
+- 必要なAPI: Maps SDK for Android/iOS, Geocoding API
+- 形式: `AIzaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`
+
+#### 2.2 本番環境でのAPIキー設定
+```bash
+# 本番環境でAPIキーを安全に設定
+./scripts/setup-production-keys.sh
+```
+
+このスクリプトの機能：
+- 📝 対話形式でAPIキー入力
+- 🔍 APIキー形式の検証
+- 🔐 Flutter Secure Storageへの暗号化保存
+- ✅ 保存確認と検証
+
+### 3. プラットフォーム別デプロイ
+
+#### 3.1 iOS本番デプロイ
+
+**前提条件**
+- Apple Developer Program登録
+- Xcode最新版
+- 証明書とプロビジョニングプロファイル
+
+**デプロイ手順**
+```bash
+# iOS本番ビルド実行
+./scripts/deploy-production.sh ios
+```
+
+**手動作業**
+1. Xcode Organizerを開く
+2. 生成されたアーカイブを選択
+3. App Store Connectにアップロード
+4. App Store Connectでリリース設定
+
+#### 3.2 Android本番デプロイ
+
+**前提条件**
+- Google Play Console登録
+- 署名キーの準備
+
+**署名キー設定**
+```bash
+# 環境変数設定
+export ANDROID_KEYSTORE_PATH="/path/to/keystore.jks"
+export ANDROID_KEY_ALIAS="your_key_alias"
+export ANDROID_KEYSTORE_PASSWORD="keystore_password"
+export ANDROID_KEY_PASSWORD="key_password"
+```
+
+**デプロイ手順**
+```bash
+# Android本番ビルド実行
+./scripts/deploy-production.sh android
+```
+
+**手動作業**
+1. Google Play Consoleにログイン
+2. アプリを選択し「リリース」→「本番環境」
+3. 生成されたApp Bundleをアップロード
+
+#### 3.3 Web本番デプロイ
+
+**デプロイ手順**
+```bash
+# Web本番ビルド実行
+./scripts/deploy-production.sh web
+```
+
+**手動作業**
+1. 生成された `build/web/` をWebサーバーにアップロード
+2. HTTPS設定
+3. セキュリティヘッダー設定
+
+## ⚙️ 設定ファイル詳細
+
+### config/production.yaml
+本番環境の設定が記載されています：
+
+```yaml
+environment:
+  name: "production"
+  debug_mode: false
+
+security:
+  encryption:
+    algorithm: "AES-256-GCM"
+  secure_storage:
+    android:
+      encrypted_shared_preferences: true
+    ios:
+      accessibility: "first_unlock_this_device"
+
+performance:
+  image_cache:
+    max_cache_size: "100MB"
+  database_optimization:
+    enable_indices: true
+```
+
+### config/staging.yaml
+ステージング環境用設定：
+
+```yaml
+environment:
+  name: "staging"
+  debug_mode: true
+
+logging:
+  level: "DEBUG"
+  console_output: true
+```
+
+## 🔒 セキュリティ考慮事項
+
+### APIキー管理
+- ✅ **本番**: Flutter Secure Storage（暗号化）
+- ✅ **開発**: `.env`ファイル（gitignore対象）
+- ❌ **禁止**: コード内ハードコーディング
+
+### データ保護
+- SQLite データベースの暗号化
+- 個人情報の適切な取り扱い
+- HTTPS通信の強制
+
+### 権限設定
+```xml
+<!-- Android: android/app/src/main/AndroidManifest.xml -->
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+```xml
+<!-- iOS: ios/Runner/Info.plist -->
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>このアプリは近くの中華料理店を検索するために位置情報を使用します</string>
+```
+
+## 📊 監視・運用
+
+### ログ監視
+- 本番環境: INFOレベル以上
+- エラー発生時の自動アラート設定推奨
+
+### パフォーマンス監視
+- アプリ起動時間
+- API応答時間
+- データベースクエリ性能
+
+### ユーザー分析
+- クラッシュレポート
+- パフォーマンス指標
+- ユーザー行動分析（プライバシー配慮）
+
+## 🚨 トラブルシューティング
+
+### よくある問題
+
+#### 1. APIキー関連エラー
+```
+Error: API key not found
+```
+**解決方法**:
+```bash
+# APIキー再設定
+./scripts/setup-production-keys.sh
+```
+
+#### 2. ビルドエラー
+```
+Error: Failed to build for production
+```
+**解決方法**:
+```bash
+# 環境リセット
+flutter clean
+flutter pub get
+./scripts/check-production-ready.sh
+```
+
+#### 3. 位置情報エラー
+```
+Error: Location permissions denied
+```
+**解決方法**:
+- AndroidManifest.xml、Info.plistの権限設定確認
+- ランタイム権限要求の実装確認
+
+## 📋 チェックリスト
+
+### デプロイ前チェック
+- [ ] `./scripts/check-production-ready.sh` 実行・合格
+- [ ] APIキー本番用に変更
+- [ ] 証明書・署名設定完了
+- [ ] テスト実行・全合格
+- [ ] セキュリティ監査実施
+
+### デプロイ後チェック
+- [ ] アプリ起動確認
+- [ ] 主要機能動作確認
+- [ ] API通信確認
+- [ ] 位置情報取得確認
+- [ ] データベース動作確認
+
+### 運用チェック
+- [ ] ログ監視設定
+- [ ] アラート設定
+- [ ] バックアップ設定
+- [ ] 更新計画策定
+
+## 🔄 アップデート手順
+
+### パッチリリース (1.0.x)
+```bash
+# バージョン更新
+# pubspec.yaml: version: 1.0.1+2
+
+# 本番デプロイ
+./scripts/deploy-production.sh [platform]
+```
+
+### マイナーリリース (1.x.0)
+```bash
+# フィーチャーブランチからマージ
+git checkout main
+git merge feature/new-feature
+
+# バージョン更新
+# pubspec.yaml: version: 1.1.0+3
+
+# 本番デプロイ
+./scripts/deploy-production.sh [platform]
+```
+
+## 🆘 緊急時対応
+
+### ロールバック手順
+1. App Store Connect / Google Play Consoleで以前のバージョンに戻す
+2. 緊急パッチの準備
+3. ユーザー告知
+
+### インシデント対応
+1. エラーログ確認
+2. 影響範囲特定
+3. 応急処置実施
+4. 根本原因調査
+5. 再発防止策実装
+
+## 📞 サポート
+
+### 技術サポート
+- 開発チーム内でのコードレビュー
+- Stack Overflow、Flutter公式ドキュメント
+
+### API サポート
+- **HotPepper API**: [リクルートサポート](https://webservice.recruit.co.jp/support/)
+- **Google Maps API**: [Google Cloud サポート](https://cloud.google.com/support)
+
+---
+
+**最終更新**: $(date +"%Y年%m月%d日")  
+**バージョン**: 1.0.0  
+**作成者**: 町中華探索アプリ開発チーム

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>12.0</string>
+  <string>14.0</string>
 </dict>
 </plist>

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Profile.xcconfig
+++ b/ios/Flutter/Profile.xcconfig
@@ -1,0 +1,2 @@
+#include "Generated.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+platform :ios, '14.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -11,9 +11,11 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		88649A7A9B20324DFCD2F806 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9F44D488CCA449D14DAC173 /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		C980CB2B086353BEB2BB21ED /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FE13F5D82C70CAA546D0BAB /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,14 +42,20 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0B73B2DF2F83C7A67FAD9F6A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2FE13F5D82C70CAA546D0BAB /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		339DAD5857BD1FA128E645DD /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		50992F87056C2C966189A36F /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		53894553AA71E737CE9D6DC5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		916D9835A7680CBA6B224CC9 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,13 +63,24 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B9F44D488CCA449D14DAC173 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB5836F924865FEC2C58CD74 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		02667AE36636C15252669CEE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C980CB2B086353BEB2BB21ED /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				88649A7A9B20324DFCD2F806 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +93,29 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		4FD8B874508A77948A15F182 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				B9F44D488CCA449D14DAC173 /* Pods_Runner.framework */,
+				2FE13F5D82C70CAA546D0BAB /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5EED4A4E4F112D09D0BC4990 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				916D9835A7680CBA6B224CC9 /* Pods-Runner.debug.xcconfig */,
+				0B73B2DF2F83C7A67FAD9F6A /* Pods-Runner.release.xcconfig */,
+				339DAD5857BD1FA128E645DD /* Pods-Runner.profile.xcconfig */,
+				EB5836F924865FEC2C58CD74 /* Pods-RunnerTests.debug.xcconfig */,
+				50992F87056C2C966189A36F /* Pods-RunnerTests.release.xcconfig */,
+				53894553AA71E737CE9D6DC5 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -94,6 +136,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				5EED4A4E4F112D09D0BC4990 /* Pods */,
+				4FD8B874508A77948A15F182 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				493BD489599F31D3FF19969F /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				02667AE36636C15252669CEE /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				ACC75F9BD4C601328DC13F38 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				C6536B6BF250FF4D69D0F662 /* [CP] Embed Pods Frameworks */,
+				15A25327ADF8112A64FDE5EB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -222,6 +271,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		15A25327ADF8112A64FDE5EB /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -238,6 +304,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		493BD489599F31D3FF19969F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -252,6 +340,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		ACC75F9BD4C601328DC13F38 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C6536B6BF250FF4D69D0F662 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -346,7 +473,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -378,6 +505,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EB5836F924865FEC2C58CD74 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -395,6 +523,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 50992F87056C2C966189A36F /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -410,6 +539,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 53894553AA71E737CE9D6DC5 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -472,7 +602,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -523,7 +653,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/core/config/config_exception.dart
+++ b/lib/core/config/config_exception.dart
@@ -16,12 +16,6 @@ class ConfigurationException implements Exception {
    GOOGLE_MAPS_API_KEY=あなたのGoogle_Maps_API_キー
 3. アプリケーションを再起動
 
-環境別設定の場合:
-   DEV_HOTPEPPER_API_KEY=開発環境用キー
-   STAGING_HOTPEPPER_API_KEY=ステージング環境用キー
-   PROD_HOTPEPPER_API_KEY=本番環境用キー
-   FLUTTER_ENV=development (または staging, production)
-
 詳細については README.md#環境設定 を参照してください。
 ''';
   }

--- a/lib/core/config/config_validator.dart
+++ b/lib/core/config/config_validator.dart
@@ -86,23 +86,14 @@ class ConfigValidator {
     final googleMapsKey = EnvironmentConfig.googleMapsApiKey;
 
     if (hotpepperKey.isEmpty) {
-      errors.add('本番環境: PROD_HOTPEPPER_API_KEY が設定されていません');
+      errors.add('本番環境: HOTPEPPER_API_KEY が設定されていません');
     }
 
     if (googleMapsKey.isEmpty) {
-      errors.add('本番環境: PROD_GOOGLE_MAPS_API_KEY が設定されていません');
+      errors.add('本番環境: GOOGLE_MAPS_API_KEY が設定されていません');
     }
 
-    // 本番環境ではフォールバック使用を警告
-    if (hotpepperKey.isEmpty &&
-        EnvironmentConfig.fallbackHotpepperApiKey.isNotEmpty) {
-      errors.add('警告: 本番環境でフォールバック HotPepper API キーを使用中');
-    }
-
-    if (googleMapsKey.isEmpty &&
-        EnvironmentConfig.fallbackGoogleMapsApiKey.isNotEmpty) {
-      errors.add('警告: 本番環境でフォールバック Google Maps API キーを使用中');
-    }
+    // フォールバック機能は削除されたため、この警告は不要
   }
 
   /// ステージング環境の設定を検証
@@ -111,11 +102,11 @@ class ConfigValidator {
     final googleMapsKey = EnvironmentConfig.googleMapsApiKey;
 
     if (hotpepperKey.isEmpty) {
-      errors.add('ステージング環境: STAGING_HOTPEPPER_API_KEY が設定されていません');
+      errors.add('ステージング環境: HOTPEPPER_API_KEY が設定されていません');
     }
 
     if (googleMapsKey.isEmpty) {
-      errors.add('ステージング環境: STAGING_GOOGLE_MAPS_API_KEY が設定されていません');
+      errors.add('ステージング環境: GOOGLE_MAPS_API_KEY が設定されていません');
     }
   }
 

--- a/lib/core/config/config_validator.dart
+++ b/lib/core/config/config_validator.dart
@@ -11,6 +11,13 @@ class ConfigValidator {
   static List<String> validateConfiguration() {
     final errors = <String>[];
 
+    // 初期化を確実に行う（同期的処理のみ）
+    if (!EnvironmentConfig.isInitialized) {
+      errors.add(
+          'EnvironmentConfigが初期化されていません。main()でEnvironmentConfig.initialize()を呼び出してください。');
+      return errors;
+    }
+
     // APIキーの存在確認
     _validateApiKeys(errors);
 

--- a/lib/core/config/environment_config.dart
+++ b/lib/core/config/environment_config.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
 /// アプリケーション環境の定義
 enum Environment {
   /// 開発環境
@@ -15,6 +17,9 @@ enum Environment {
 
 /// 環境別設定管理クラス
 class EnvironmentConfig {
+  // 初期化フラグ
+  static bool _initialized = false;
+
   /// 現在の環境を取得
   static Environment get current {
     const env =
@@ -37,20 +42,42 @@ class EnvironmentConfig {
   /// 現在の環境が本番環境かどうか
   static bool get isProduction => current == Environment.production;
 
+  /// 初期化（.envファイル読み込み）
+  static Future<void> initialize() async {
+    if (_initialized) return;
+
+    try {
+      await dotenv.load();
+    } catch (e) {
+      // .envファイルが存在しない場合は無視
+    }
+
+    _initialized = true;
+  }
+
   /// HotPepper API キーを取得（全環境共通）
   static String get hotpepperApiKey {
-    return const String.fromEnvironment(
-      'HOTPEPPER_API_KEY',
-      defaultValue: '',
-    );
+    // .envファイルから取得を試行
+    final envKey = dotenv.env['HOTPEPPER_API_KEY'];
+    if (envKey != null && envKey.isNotEmpty) {
+      return envKey;
+    }
+
+    // 環境変数から取得（フォールバック）
+    return const String.fromEnvironment('HOTPEPPER_API_KEY', defaultValue: '');
   }
 
   /// Google Maps API キーを取得（全環境共通）
   static String get googleMapsApiKey {
-    return const String.fromEnvironment(
-      'GOOGLE_MAPS_API_KEY',
-      defaultValue: '',
-    );
+    // .envファイルから取得を試行
+    final envKey = dotenv.env['GOOGLE_MAPS_API_KEY'];
+    if (envKey != null && envKey.isNotEmpty) {
+      return envKey;
+    }
+
+    // 環境変数から取得（フォールバック）
+    return const String.fromEnvironment('GOOGLE_MAPS_API_KEY',
+        defaultValue: '');
   }
 
   /// 実際に使用するHotPepper APIキーを取得
@@ -58,6 +85,9 @@ class EnvironmentConfig {
 
   /// 実際に使用するGoogle Maps APIキーを取得
   static String get effectiveGoogleMapsApiKey => googleMapsApiKey;
+
+  /// 初期化されているかどうかを確認
+  static bool get isInitialized => _initialized;
 
   /// HotPepper API のベースURL
   static String get hotpepperApiUrl {

--- a/lib/core/config/environment_config.dart
+++ b/lib/core/config/environment_config.dart
@@ -37,80 +37,27 @@ class EnvironmentConfig {
   /// 現在の環境が本番環境かどうか
   static bool get isProduction => current == Environment.production;
 
-  /// HotPepper API キーを環境別に取得
+  /// HotPepper API キーを取得（全環境共通）
   static String get hotpepperApiKey {
-    switch (current) {
-      case Environment.development:
-        return const String.fromEnvironment(
-          'DEV_HOTPEPPER_API_KEY',
-          defaultValue: '',
-        );
-      case Environment.staging:
-        return const String.fromEnvironment(
-          'STAGING_HOTPEPPER_API_KEY',
-          defaultValue: '',
-        );
-      case Environment.production:
-        return const String.fromEnvironment(
-          'PROD_HOTPEPPER_API_KEY',
-          defaultValue: '',
-        );
-    }
+    return const String.fromEnvironment(
+      'HOTPEPPER_API_KEY',
+      defaultValue: '',
+    );
   }
 
-  /// Google Maps API キーを環境別に取得
+  /// Google Maps API キーを取得（全環境共通）
   static String get googleMapsApiKey {
-    switch (current) {
-      case Environment.development:
-        return const String.fromEnvironment(
-          'DEV_GOOGLE_MAPS_API_KEY',
-          defaultValue: '',
-        );
-      case Environment.staging:
-        return const String.fromEnvironment(
-          'STAGING_GOOGLE_MAPS_API_KEY',
-          defaultValue: '',
-        );
-      case Environment.production:
-        return const String.fromEnvironment(
-          'PROD_GOOGLE_MAPS_API_KEY',
-          defaultValue: '',
-        );
-    }
+    return const String.fromEnvironment(
+      'GOOGLE_MAPS_API_KEY',
+      defaultValue: '',
+    );
   }
 
-  /// フォールバック用の単一APIキー（既存の設定と互換性維持）
-  static String get fallbackHotpepperApiKey {
-    return const String.fromEnvironment('HOTPEPPER_API_KEY', defaultValue: '');
-  }
+  /// 実際に使用するHotPepper APIキーを取得
+  static String get effectiveHotpepperApiKey => hotpepperApiKey;
 
-  /// フォールバック用の単一APIキー（既存の設定と互換性維持）
-  static String get fallbackGoogleMapsApiKey {
-    return const String.fromEnvironment('GOOGLE_MAPS_API_KEY',
-        defaultValue: '');
-  }
-
-  /// 実際に使用するHotPepper APIキーを取得（環境別 > フォールバック）
-  static String get effectiveHotpepperApiKey {
-    final envKey = hotpepperApiKey;
-    if (envKey.isNotEmpty) return envKey;
-
-    final fallbackKey = fallbackHotpepperApiKey;
-    if (fallbackKey.isNotEmpty) return fallbackKey;
-
-    return '';
-  }
-
-  /// 実際に使用するGoogle Maps APIキーを取得（環境別 > フォールバック）
-  static String get effectiveGoogleMapsApiKey {
-    final envKey = googleMapsApiKey;
-    if (envKey.isNotEmpty) return envKey;
-
-    final fallbackKey = fallbackGoogleMapsApiKey;
-    if (fallbackKey.isNotEmpty) return fallbackKey;
-
-    return '';
-  }
+  /// 実際に使用するGoogle Maps APIキーを取得
+  static String get effectiveGoogleMapsApiKey => googleMapsApiKey;
 
   /// HotPepper API のベースURL
   static String get hotpepperApiUrl {

--- a/lib/core/config/ui_config.dart
+++ b/lib/core/config/ui_config.dart
@@ -8,7 +8,7 @@ class UiConfig {
   static const String appDescription = '町中華探索アプリ';
 
   /// レイアウト設定
-  static const double cardBorderRadius = 12.0;
+  static const double cardBorderRadius = 14.0;
   static const double defaultPadding = 16.0;
   static const double smallPadding = 8.0;
   static const double largePadding = 24.0;
@@ -33,7 +33,7 @@ class UiConfig {
   static const double titleFontSize = 24.0;
   static const double subtitleFontSize = 18.0;
   static const double bodyFontSize = 16.0;
-  static const double captionFontSize = 12.0;
+  static const double captionFontSize = 14.0;
 
   /// アイコン設定
   static const double defaultIconSize = 24.0;

--- a/lib/core/di/app_di_container.dart
+++ b/lib/core/di/app_di_container.dart
@@ -4,6 +4,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'dart:io' show File;
 import '../config/app_config.dart';
+import '../config/environment_config.dart' as env_config;
 import '../database/schema/app_database.dart';
 import '../network/app_http_client.dart';
 import '../../data/datasources/hotpepper_api_datasource.dart';
@@ -126,14 +127,25 @@ class AppDIContainer implements DIContainerInterface {
 
   /// Create API datasource for development environment
   HotpepperApiDatasource _createApiDatasourceForDevelopment() {
-    // In development, always try to use real API if key is available
-    if (AppConfig.hasHotpepperApiKey) {
-      developer.log('Using real HotPepper API datasource (development)',
-          name: 'DI');
-      return HotpepperApiDatasourceImpl(AppHttpClient());
-    } else {
+    // In development, use EnvironmentConfig which properly reads from .env files
+    try {
+      // Ensure EnvironmentConfig is initialized and check for API key
+      final apiKey = env_config.EnvironmentConfig.hotpepperApiKey;
+      if (apiKey.isNotEmpty) {
+        developer.log(
+            'Using real HotPepper API datasource (development) - API key found',
+            name: 'DI');
+        return HotpepperApiDatasourceImpl(AppHttpClient());
+      } else {
+        developer.log(
+            'API key not available, using mock datasource (development)',
+            name: 'DI',
+            level: 900); // WARNING level
+        return MockHotpepperApiDatasource();
+      }
+    } catch (e) {
       developer.log(
-          'API key not available, using mock datasource (development)',
+          'Error checking API key, using mock datasource (development): $e',
           name: 'DI',
           level: 900); // WARNING level
       return MockHotpepperApiDatasource();

--- a/lib/core/di/di_container.dart
+++ b/lib/core/di/di_container.dart
@@ -39,11 +39,14 @@ class DIContainer {
 
   /// 環境に応じたAPIデータソースを作成
   static HotpepperApiDatasource _createApiDatasource() {
-    if (AppConfig.hasHotpepperApiKey && AppConfig.isProduction) {
-      // 本番環境ではAPIキーが設定されている場合のみ実API使用
+    if (AppConfig.isProduction) {
+      // 本番環境では常に実APIを使用
+      return HotpepperApiDatasourceImpl(AppHttpClient());
+    } else if (AppConfig.hasHotpepperApiKey) {
+      // 開発環境でAPIキーが設定されている場合は実API使用
       return HotpepperApiDatasourceImpl(AppHttpClient());
     } else {
-      // 開発環境またはAPIキー未設定時はモック使用
+      // APIキー未設定時はモック使用
       return MockHotpepperApiDatasource();
     }
   }

--- a/lib/data/models/hotpepper_store_model.dart
+++ b/lib/data/models/hotpepper_store_model.dart
@@ -173,9 +173,17 @@ class HotpepperSearchResponse {
               HotpepperStoreModel.fromJson(shop as Map<String, dynamic>))
           .toList(),
       resultsAvailable: results['results_available'] as int? ?? 0,
-      resultsReturned: results['results_returned'] as int? ?? 0,
+      resultsReturned: _parseIntSafely(results['results_returned']) ?? 0,
       resultsStart: results['results_start'] as int? ?? 1,
     );
+  }
+
+  /// 文字列または数値を安全にintに変換
+  static int? _parseIntSafely(dynamic value) {
+    if (value == null) return null;
+    if (value is int) return value;
+    if (value is String) return int.tryParse(value);
+    return null;
   }
 
   /// JSON文字列からレスポンスモデルを作成

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'core/config/config_manager.dart';
+import 'core/config/environment_config.dart';
 import 'core/constants/app_constants.dart';
 import 'core/di/app_di_container.dart';
 import 'core/di/di_container_interface.dart';
@@ -22,6 +23,9 @@ Future<void> main() async {
   // 設定管理を初期化（テスト環境では初期化をスキップ）
   if (!_isTestEnvironment()) {
     try {
+      // 環境設定を先に初期化
+      await EnvironmentConfig.initialize();
+
       await ConfigManager.initialize(
         throwOnValidationError: false, // 開発環境では警告のみ
         enableDebugLogging: true,

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import app_settings
 import file_selector_macos
 import flutter_secure_storage_macos
 import geolocator_apple
+import package_info_plus
 import path_provider_foundation
 import sqflite_darwin
 import sqlite3_flutter_libs
@@ -18,6 +19,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f6154230675c44a191f2e20d16eeceb4aa18b30ca732db4efaf94c6a7d43cfa6
+      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.5.2"
+    version: "7.7.1"
   app_settings:
     dependency: "direct main"
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      sha256: "7d95cbbb1526ab5ae977df9b4cc660963b9b27f6d1075c0b34653868911385e4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.0.0"
   build_config:
     dependency: transitive
     description:
@@ -77,26 +77,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
+      sha256: "38c9c339333a09b090a638849a4c56e70a404c6bdd3b511493addfbc113b60c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.0.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      sha256: b971d4a1c789eba7be3e6fe6ce5e5b50fd3719e3cb485b3fad6d04358304351d
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.6.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
+      sha256: c04e612ca801cd0928ccdb891c263a2b1391cb27940a5ea5afcf9ba894de5d62
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.2"
+    version: "9.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
+      sha256: "0b1b12a0a549605e5f04476031cd0bc91ead1d7c8e830773a18ee54179b3cb62"
       url: "https://pub.dev"
     source: hosted
-    version: "8.10.1"
+    version: "8.11.0"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -237,34 +237,42 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
+      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   drift:
     dependency: "direct main"
     description:
       name: drift
-      sha256: e60c715f045dd33624fc533efb0075e057debec9f39e83843e518f488a0e21fb
+      sha256: "6aaea757f53bb035e8a3baedf3d1d53a79d6549a6c13d84f7546509da9372c7c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.27.0"
+    version: "2.28.1"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "7ad88b8982e753eadcdbc0ea7c7d30500598af733601428b5c9d264baf5106d6"
+      sha256: "2fc05ad458a7c562755bf0cae11178dfc58387a416829b78d4da5155a61465fd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.27.0"
+    version: "2.28.1"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: "0cadbf3b8733409a6cf61d18ba2e94e149df81df7de26f48ae0695b48fd71922"
+      sha256: ccfb42bc942e59f81500b16228df59cf8eb40d2fbd96637ff677df923350af7b
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.5"
   fake_async:
     dependency: transitive
     description:
@@ -440,6 +448,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  geoclue:
+    dependency: transitive
+    description:
+      name: geoclue
+      sha256: c2a998c77474fc57aa00c6baa2928e58f4b267649057a1c76738656e9dbd2a7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   geocoding:
     dependency: "direct main"
     description:
@@ -460,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: geocoding_ios
-      sha256: "43bde988312feb1a3cb6c3d514e9f4b04b564d1884fa56bd8241030bbb3bde36"
+      sha256: "18ab1c8369e2b0dcb3a8ccc907319334f35ee8cf4cfef4d9c8e23b13c65cb825"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   geocoding_platform_interface:
     dependency: transitive
     description:
@@ -476,18 +492,18 @@ packages:
     dependency: "direct main"
     description:
       name: geolocator
-      sha256: ee2212a3df8292ec4c90b91183b8001d3f5a800823c974b570c5f9344ca320dc
+      sha256: "79939537046c9025be47ec645f35c8090ecadb6fe98eba146a0d25e8c1357516"
       url: "https://pub.dev"
     source: hosted
-    version: "14.0.1"
+    version: "14.0.2"
   geolocator_android:
     dependency: transitive
     description:
       name: geolocator_android
-      sha256: "114072db5d1dce0ec0b36af2697f55c133bc89a2c8dd513e137c0afe59696ed4"
+      sha256: "179c3cb66dfa674fc9ccbf2be872a02658724d1c067634e2c427cf6df7df901a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1+1"
+    version: "5.0.2"
   geolocator_apple:
     dependency: transitive
     description:
@@ -496,6 +512,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.13"
+  geolocator_linux:
+    dependency: transitive
+    description:
+      name: geolocator_linux
+      sha256: c4e966f0a7a87e70049eac7a2617f9e16fd4c585a26e4330bdfc3a71e6a721f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
   geolocator_platform_interface:
     dependency: transitive
     description:
@@ -556,10 +580,10 @@ packages:
     dependency: transitive
     description:
       name: google_maps_flutter_android
-      sha256: ab83128296fbeaa52e8f2b3bf53bcd895e64778edddcdc07bc8f33f4ea78076c
+      sha256: "67745f7850655faa8a596606b627fece63f3011078eaa0c151a4774568c23ac4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.16.1"
+    version: "2.17.0"
   google_maps_flutter_ios:
     dependency: transitive
     description:
@@ -592,6 +616,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gsettings:
+    dependency: transitive
+    description:
+      name: gsettings
+      sha256: "1b0ce661f5436d2db1e51f3c4295a49849f03d304003a7ba177d01e3a858249c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   html:
     dependency: transitive
     description:
@@ -636,10 +668,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "317a5d961cec5b34e777b9252393f2afbd23084aa6e60fcf601dcf6341b9ebeb"
+      sha256: "6fae381e6af2bbe0365a5e4ce1db3959462fa0c4d234facf070746024bb80c8d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+23"
+    version: "0.8.12+24"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -788,10 +820,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "4546eac99e8967ea91bae633d2ca7698181d008e95fa4627330cf903d573277a"
+      sha256: "2314cbe9165bcd16106513df9cf3c3224713087f09723b128928dc11a4379f99"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.6"
+    version: "5.5.0"
   nested:
     dependency: transitive
     description:
@@ -816,6 +848,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   path:
     dependency: "direct main"
     description:
@@ -872,6 +920,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   platform:
     dependency: transitive
     description:
@@ -977,10 +1033,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: fc787b1f89ceac9580c3616f899c9a447413cbdac1df071302127764c023a134
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   source_span:
     dependency: transitive
     description:
@@ -1017,10 +1073,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
+      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.5"
+    version: "2.5.6"
   sqflite_common_ffi:
     dependency: "direct dev"
     description:
@@ -1049,26 +1105,26 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: c0503c69b44d5714e6abbf4c1f51a3c3cc42b75ce785f44404765e4635481d38
+      sha256: dd806fff004a0aeb01e208b858dbc649bc72104670d425a81a6dd17698535f6e
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.6"
+    version: "2.8.0"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
-      sha256: e07232b998755fe795655c56d1f5426e0190c9c435e1752d39e7b1cd33699c71
+      sha256: fd996da5515a73aacd0a04ae7063db5fe8df42670d974df4c3ee538c652eef2e
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.34"
+    version: "0.5.38"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "27dd0a9f0c02e22ac0eb42a23df9ea079ce69b52bb4a3b478d64e0ef34a263ee"
+      sha256: "7c859c803cf7e9a84d6db918bac824545045692bbe94a6386bd3a45132235d09"
       url: "https://pub.dev"
     source: hosted
-    version: "0.41.0"
+    version: "0.41.1"
   stack_trace:
     dependency: transitive
     description:
@@ -1213,6 +1269,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -101,8 +101,8 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - .env  # 開発時に必要に応じて有効化
+  assets:
+    - .env  # 開発時に必要に応じて有効化
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images

--- a/scripts/check-production-ready.sh
+++ b/scripts/check-production-ready.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+
+# 本番環境準備チェックスクリプト
+# check-production-ready.sh
+# 
+# 本番リリース前の総合チェックを実行します
+
+set -e
+
+# カラー定義
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+NC='\033[0m'
+
+# チェック結果カウンター
+PASSED=0
+FAILED=0
+WARNINGS=0
+
+# チェック結果を記録する関数
+check_pass() {
+    echo -e "${GREEN}✅ $1${NC}"
+    ((PASSED++))
+}
+
+check_fail() {
+    echo -e "${RED}❌ $1${NC}"
+    ((FAILED++))
+}
+
+check_warn() {
+    echo -e "${YELLOW}⚠️  $1${NC}"
+    ((WARNINGS++))
+}
+
+echo -e "${PURPLE}"
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║              本番環境準備チェックスクリプト                  ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+echo -e "${BLUE}🔍 本番リリース前の総合チェックを開始します...${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# 1. 開発環境チェック
+echo -e "\n${BLUE}📦 1. 開発環境チェック${NC}"
+
+# Flutter環境
+if command -v flutter &> /dev/null; then
+    FLUTTER_VERSION=$(flutter --version | head -n 1)
+    check_pass "Flutter環境: $FLUTTER_VERSION"
+else
+    check_fail "Flutter SDKが見つかりません"
+fi
+
+# Dart環境
+if command -v dart &> /dev/null; then
+    DART_VERSION=$(dart --version | cut -d' ' -f4)
+    check_pass "Dart環境: $DART_VERSION"
+else
+    check_fail "Dart SDKが見つかりません"
+fi
+
+# 2. プロジェクト構成チェック
+echo -e "\n${BLUE}📁 2. プロジェクト構成チェック${NC}"
+
+# 必須ファイルの存在確認
+required_files=(
+    "pubspec.yaml"
+    "lib/main.dart"
+    "config/production.yaml"
+    "config/staging.yaml"
+    "scripts/deploy-production.sh"
+    "scripts/setup-production-keys.sh"
+)
+
+for file in "${required_files[@]}"; do
+    if [ -f "$file" ]; then
+        check_pass "必須ファイル存在: $file"
+    else
+        check_fail "必須ファイル不足: $file"
+    fi
+done
+
+# .gitignore チェック
+if grep -q "\.env" .gitignore && grep -q "CLAUDE\.md" .gitignore; then
+    check_pass ".gitignore設定: 機密情報が適切に除外されています"
+else
+    check_warn ".gitignore設定: 機密情報の除外設定を確認してください"
+fi
+
+# 3. コード品質チェック
+echo -e "\n${BLUE}🔍 3. コード品質チェック${NC}"
+
+# フォーマットチェック
+if dart format --set-exit-if-changed . &> /dev/null; then
+    check_pass "コードフォーマット: 適切にフォーマットされています"
+else
+    check_fail "コードフォーマット: dart format . を実行してください"
+fi
+
+# 静的解析
+if flutter analyze &> /dev/null; then
+    check_pass "静的解析: エラーなし"
+else
+    check_fail "静的解析: 修正が必要なエラーがあります"
+fi
+
+# 4. テストチェック
+echo -e "\n${BLUE}🧪 4. テストチェック${NC}"
+
+# テスト実行
+TEST_OUTPUT=$(flutter test 2>&1)
+if echo "$TEST_OUTPUT" | grep -q "All tests passed"; then
+    TEST_COUNT=$(echo "$TEST_OUTPUT" | grep -o '[0-9]\+ tests' | head -1)
+    check_pass "全テスト合格: $TEST_COUNT"
+else
+    check_fail "テスト失敗: 修正が必要です"
+fi
+
+# テストカバレッジチェック（実行可能な場合）
+if flutter test --coverage &> /dev/null; then
+    if [ -f "coverage/lcov.info" ]; then
+        check_pass "テストカバレッジ: 生成済み"
+    else
+        check_warn "テストカバレッジ: 生成に失敗"
+    fi
+fi
+
+# 5. セキュリティチェック
+echo -e "\n${BLUE}🔒 5. セキュリティチェック${NC}"
+
+# APIキーハードコーディングチェック
+if grep -r "YOUR_API_KEY_HERE" lib/ &> /dev/null; then
+    check_fail "セキュリティ: プレースホルダーAPIキーが残っています"
+else
+    check_pass "セキュリティ: プレースホルダーAPIキーなし"
+fi
+
+# パスワードやトークンの検出
+if grep -ri -E "(password|token|secret|key)\s*[:=]\s*['\"][^'\"]{8,}" lib/ &> /dev/null; then
+    check_warn "セキュリティ: 機密情報がハードコーディングされている可能性があります"
+else
+    check_pass "セキュリティ: 機密情報のハードコーディングなし"
+fi
+
+# 6. 依存関係チェック
+echo -e "\n${BLUE}📦 6. 依存関係チェック${NC}"
+
+# pubspec.lock の存在
+if [ -f "pubspec.lock" ]; then
+    check_pass "依存関係: pubspec.lock 存在"
+else
+    check_fail "依存関係: flutter pub get を実行してください"
+fi
+
+# 脆弱性チェック（簡易版）
+OUTDATED_OUTPUT=$(flutter pub outdated 2>&1 || true)
+if echo "$OUTDATED_OUTPUT" | grep -q "No dependencies"; then
+    check_pass "依存関係: 最新状態"
+else
+    check_warn "依存関係: 更新可能なパッケージがあります"
+fi
+
+# 7. ビルドチェック
+echo -e "\n${BLUE}🔨 7. ビルドチェック${NC}"
+
+# Androidビルドチェック
+if flutter build apk --debug &> /dev/null; then
+    check_pass "Android: デバッグビルド成功"
+else
+    check_fail "Android: デバッグビルドに失敗"
+fi
+
+# iOSビルドチェック（macOSの場合のみ）
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if flutter build ios --simulator --debug &> /dev/null; then
+        check_pass "iOS: シミュレーターデバッグビルド成功"
+    else
+        check_fail "iOS: シミュレーターデバッグビルドに失敗"
+    fi
+fi
+
+# 8. 設定ファイルチェック
+echo -e "\n${BLUE}⚙️  8. 設定ファイルチェック${NC}"
+
+# production.yaml チェック
+if [ -f "config/production.yaml" ]; then
+    if grep -q "environment:" config/production.yaml; then
+        check_pass "本番設定: production.yaml が適切に設定されています"
+    else
+        check_warn "本番設定: production.yaml の設定を確認してください"
+    fi
+else
+    check_fail "本番設定: config/production.yaml が見つかりません"
+fi
+
+# 9. APIキー設定チェック
+echo -e "\n${BLUE}🔑 9. APIキー設定チェック${NC}"
+
+# 環境変数チェック
+if [ -n "$PROD_HOTPEPPER_API_KEY" ] || [ -n "$HOTPEPPER_API_KEY" ]; then
+    check_pass "HotPepper APIキー: 環境変数に設定済み"
+else
+    check_warn "HotPepper APIキー: 環境変数未設定（本番では Secure Storage から取得）"
+fi
+
+if [ -n "$PROD_GOOGLE_MAPS_API_KEY" ] || [ -n "$GOOGLE_MAPS_API_KEY" ]; then
+    check_pass "Google Maps APIキー: 環境変数に設定済み"
+else
+    check_warn "Google Maps APIキー: 環境変数未設定（本番では Secure Storage から取得）"
+fi
+
+# 10. デプロイスクリプトチェック
+echo -e "\n${BLUE}🚀 10. デプロイスクリプトチェック${NC}"
+
+if [ -x "scripts/deploy-production.sh" ]; then
+    check_pass "デプロイスクリプト: 実行可能"
+else
+    check_fail "デプロイスクリプト: 実行権限がありません"
+fi
+
+if [ -x "scripts/setup-production-keys.sh" ]; then
+    check_pass "APIキー設定スクリプト: 実行可能"
+else
+    check_fail "APIキー設定スクリプト: 実行権限がありません"
+fi
+
+# 結果サマリー
+echo ""
+echo -e "${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${PURPLE}📊 チェック結果サマリー${NC}"
+echo -e "${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo -e "${GREEN}✅ 合格: $PASSED 項目${NC}"
+echo -e "${RED}❌ 失敗: $FAILED 項目${NC}"
+echo -e "${YELLOW}⚠️  警告: $WARNINGS 項目${NC}"
+echo ""
+
+# 本番リリース判定
+if [ $FAILED -eq 0 ]; then
+    if [ $WARNINGS -eq 0 ]; then
+        echo -e "${GREEN}🎉 本番リリース準備完了！${NC}"
+        echo -e "${GREEN}すべてのチェックに合格しました。安心してリリースできます。${NC}"
+        exit_code=0
+    else
+        echo -e "${YELLOW}⚠️  本番リリース注意！${NC}"
+        echo -e "${YELLOW}警告項目がありますが、リリース可能です。警告内容を確認してください。${NC}"
+        exit_code=0
+    fi
+else
+    echo -e "${RED}🚫 本番リリース未準備！${NC}"
+    echo -e "${RED}失敗項目を修正してから再度チェックしてください。${NC}"
+    exit_code=1
+fi
+
+echo ""
+echo -e "${BLUE}📋 次のアクション:${NC}"
+if [ $FAILED -eq 0 ]; then
+    echo "1. 本番環境でのAPIキー設定: ./scripts/setup-production-keys.sh"
+    echo "2. 本番デプロイ実行: ./scripts/deploy-production.sh [ios|android|web]"
+    echo "3. リリース後のモニタリング実施"
+else
+    echo "1. 失敗項目の修正"
+    echo "2. 再度チェック実行: ./scripts/check-production-ready.sh"
+fi
+
+echo ""
+echo -e "${PURPLE}🏁 本番環境準備チェック完了${NC}"
+
+exit $exit_code

--- a/scripts/check-production-ready.sh
+++ b/scripts/check-production-ready.sh
@@ -202,13 +202,13 @@ fi
 echo -e "\n${BLUE}🔑 9. APIキー設定チェック${NC}"
 
 # 環境変数チェック
-if [ -n "$PROD_HOTPEPPER_API_KEY" ] || [ -n "$HOTPEPPER_API_KEY" ]; then
+if [ -n "$HOTPEPPER_API_KEY" ]; then
     check_pass "HotPepper APIキー: 環境変数に設定済み"
 else
     check_warn "HotPepper APIキー: 環境変数未設定（本番では Secure Storage から取得）"
 fi
 
-if [ -n "$PROD_GOOGLE_MAPS_API_KEY" ] || [ -n "$GOOGLE_MAPS_API_KEY" ]; then
+if [ -n "$GOOGLE_MAPS_API_KEY" ]; then
     check_pass "Google Maps APIキー: 環境変数に設定済み"
 else
     check_warn "Google Maps APIキー: 環境変数未設定（本番では Secure Storage から取得）"

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+
+# 本番環境デプロイスクリプト
+# deploy-production.sh
+#
+# 使用方法:
+#   ./scripts/deploy-production.sh ios
+#   ./scripts/deploy-production.sh android
+#   ./scripts/deploy-production.sh web
+
+set -e  # エラー時に停止
+
+# カラー定義
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # カラーリセット
+
+# ロゴ表示
+echo -e "${BLUE}"
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║              町中華探索アプリ「マチアプ」                    ║"
+echo "║                本番環境デプロイスクリプト                    ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+# 引数チェック
+if [ $# -eq 0 ]; then
+    echo -e "${RED}❌ エラー: プラットフォームを指定してください${NC}"
+    echo "使用方法: $0 [ios|android|web]"
+    exit 1
+fi
+
+PLATFORM=$1
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BUILD_DIR="build/production_${PLATFORM}_${TIMESTAMP}"
+
+echo -e "${BLUE}🚀 本番環境デプロイ開始: ${PLATFORM}${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# 1. 前提条件チェック
+echo -e "${YELLOW}📋 前提条件チェック中...${NC}"
+
+# Flutter環境チェック
+if ! command -v flutter &> /dev/null; then
+    echo -e "${RED}❌ Flutter SDKが見つかりません${NC}"
+    exit 1
+fi
+
+# APIキー環境変数チェック
+if [ -z "$PROD_HOTPEPPER_API_KEY" ] && [ -z "$HOTPEPPER_API_KEY" ]; then
+    echo -e "${RED}❌ HotPepper APIキーが設定されていません${NC}"
+    echo "環境変数 PROD_HOTPEPPER_API_KEY または HOTPEPPER_API_KEY を設定してください"
+    exit 1
+fi
+
+if [ -z "$PROD_GOOGLE_MAPS_API_KEY" ] && [ -z "$GOOGLE_MAPS_API_KEY" ]; then
+    echo -e "${RED}❌ Google Maps APIキーが設定されていません${NC}"
+    echo "環境変数 PROD_GOOGLE_MAPS_API_KEY または GOOGLE_MAPS_API_KEY を設定してください"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ 前提条件チェック完了${NC}"
+
+# 2. プロジェクトクリーンアップ
+echo -e "${YELLOW}🧹 プロジェクトクリーンアップ中...${NC}"
+flutter clean
+flutter pub get
+
+# 3. コード品質チェック
+echo -e "${YELLOW}🔍 コード品質チェック中...${NC}"
+
+# フォーマットチェック
+if ! dart format --set-exit-if-changed .; then
+    echo -e "${RED}❌ コードフォーマットエラー: dart format . を実行してください${NC}"
+    exit 1
+fi
+
+# 静的解析
+if ! flutter analyze; then
+    echo -e "${RED}❌ 静的解析エラー: 修正が必要です${NC}"
+    exit 1
+fi
+
+# テスト実行
+echo -e "${YELLOW}🧪 テスト実行中...${NC}"
+if ! flutter test; then
+    echo -e "${RED}❌ テストエラー: 修正が必要です${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ コード品質チェック完了${NC}"
+
+# 4. ビルド
+echo -e "${YELLOW}🔨 本番ビルド中...${NC}"
+mkdir -p "$BUILD_DIR"
+
+case $PLATFORM in
+    "ios")
+        echo -e "${BLUE}📱 iOS本番ビルド中...${NC}"
+        
+        # iOS証明書チェック
+        echo "証明書とプロビジョニングプロファイルを確認してください"
+        
+        # 本番ビルド実行
+        flutter build ios \
+            --release \
+            --dart-define=FLUTTER_ENV=production \
+            --dart-define=PRODUCTION=true \
+            --dart-define=PROD_HOTPEPPER_API_KEY="$PROD_HOTPEPPER_API_KEY" \
+            --dart-define=PROD_GOOGLE_MAPS_API_KEY="$PROD_GOOGLE_MAPS_API_KEY" \
+            --build-name=1.0.0 \
+            --build-number="$(date +%Y%m%d%H%M)"
+            
+        # Xcodeアーカイブ作成
+        echo -e "${BLUE}📦 Xcodeアーカイブ作成中...${NC}"
+        cd ios
+        xcodebuild \
+            -workspace Runner.xcworkspace \
+            -scheme Runner \
+            -configuration Release \
+            -destination generic/platform=iOS \
+            -archivePath "../${BUILD_DIR}/Runner.xcarchive" \
+            archive
+        cd ..
+        
+        echo -e "${GREEN}✅ iOS本番ビルド完了${NC}"
+        echo "アーカイブ場所: ${BUILD_DIR}/Runner.xcarchive"
+        echo ""
+        echo -e "${YELLOW}📤 次のステップ:${NC}"
+        echo "1. Xcode Organizerを開く"
+        echo "2. アーカイブを選択してApp Store Connectにアップロード"
+        echo "3. App Store Connectでリリース設定"
+        ;;
+        
+    "android")
+        echo -e "${BLUE}🤖 Android本番ビルド中...${NC}"
+        
+        # Android署名キーチェック
+        if [ -z "$ANDROID_KEYSTORE_PATH" ] || [ -z "$ANDROID_KEY_ALIAS" ]; then
+            echo -e "${YELLOW}⚠️  Android署名キーが未設定です${NC}"
+            echo "環境変数を設定してください:"
+            echo "- ANDROID_KEYSTORE_PATH"
+            echo "- ANDROID_KEY_ALIAS"
+            echo "- ANDROID_KEYSTORE_PASSWORD"
+            echo "- ANDROID_KEY_PASSWORD"
+        fi
+        
+        # App Bundle作成
+        flutter build appbundle \
+            --release \
+            --dart-define=FLUTTER_ENV=production \
+            --dart-define=PRODUCTION=true \
+            --dart-define=PROD_HOTPEPPER_API_KEY="$PROD_HOTPEPPER_API_KEY" \
+            --dart-define=PROD_GOOGLE_MAPS_API_KEY="$PROD_GOOGLE_MAPS_API_KEY" \
+            --build-name=1.0.0 \
+            --build-number="$(date +%Y%m%d%H%M)" \
+            --obfuscate \
+            --split-debug-info="${BUILD_DIR}/debug_symbols"
+            
+        # ビルド成果物コピー
+        cp build/app/outputs/bundle/release/app-release.aab "${BUILD_DIR}/"
+        
+        echo -e "${GREEN}✅ Android本番ビルド完了${NC}"
+        echo "App Bundle場所: ${BUILD_DIR}/app-release.aab"
+        echo ""
+        echo -e "${YELLOW}📤 次のステップ:${NC}"
+        echo "1. Google Play Consoleにログイン"
+        echo "2. アプリを選択し、「リリース」> 「本番環境」"
+        echo "3. App Bundleをアップロード"
+        ;;
+        
+    "web")
+        echo -e "${BLUE}🌐 Web本番ビルド中...${NC}"
+        
+        flutter build web \
+            --release \
+            --dart-define=FLUTTER_ENV=production \
+            --dart-define=PRODUCTION=true \
+            --dart-define=PROD_HOTPEPPER_API_KEY="$PROD_HOTPEPPER_API_KEY" \
+            --dart-define=PROD_GOOGLE_MAPS_API_KEY="$PROD_GOOGLE_MAPS_API_KEY" \
+            --web-renderer=html \
+            --base-href="/"
+            
+        # ビルド成果物コピー
+        cp -r build/web "${BUILD_DIR}/"
+        
+        echo -e "${GREEN}✅ Web本番ビルド完了${NC}"
+        echo "Webビルド場所: ${BUILD_DIR}/web/"
+        echo ""
+        echo -e "${YELLOW}📤 次のステップ:${NC}"
+        echo "1. Webサーバーに ${BUILD_DIR}/web/ の内容をアップロード"
+        echo "2. HTTPSを有効化"
+        echo "3. セキュリティヘッダーを設定"
+        ;;
+        
+    *)
+        echo -e "${RED}❌ 不正なプラットフォーム: $PLATFORM${NC}"
+        echo "対応プラットフォーム: ios, android, web"
+        exit 1
+        ;;
+esac
+
+# 5. デプロイ完了
+echo ""
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}🎉 本番環境デプロイ準備完了！${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo -e "${BLUE}📊 ビルド情報:${NC}"
+echo "プラットフォーム: $PLATFORM"
+echo "ビルド時刻: $(date)"
+echo "ビルドディレクトリ: $BUILD_DIR"
+echo ""
+echo -e "${YELLOW}⚠️  重要な注意事項:${NC}"
+echo "1. 本番環境でのテストを十分に実施してください"
+echo "2. ロールバック計画を準備してください"
+echo "3. ユーザーへの告知を検討してください"
+echo "4. リリース後のモニタリングを実施してください"
+echo ""
+echo -e "${GREEN}🚀 デプロイスクリプト完了${NC}"

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -49,15 +49,15 @@ if ! command -v flutter &> /dev/null; then
 fi
 
 # APIキー環境変数チェック
-if [ -z "$PROD_HOTPEPPER_API_KEY" ] && [ -z "$HOTPEPPER_API_KEY" ]; then
+if [ -z "$HOTPEPPER_API_KEY" ]; then
     echo -e "${RED}❌ HotPepper APIキーが設定されていません${NC}"
-    echo "環境変数 PROD_HOTPEPPER_API_KEY または HOTPEPPER_API_KEY を設定してください"
+    echo "環境変数 HOTPEPPER_API_KEY を設定してください"
     exit 1
 fi
 
-if [ -z "$PROD_GOOGLE_MAPS_API_KEY" ] && [ -z "$GOOGLE_MAPS_API_KEY" ]; then
+if [ -z "$GOOGLE_MAPS_API_KEY" ]; then
     echo -e "${RED}❌ Google Maps APIキーが設定されていません${NC}"
-    echo "環境変数 PROD_GOOGLE_MAPS_API_KEY または GOOGLE_MAPS_API_KEY を設定してください"
+    echo "環境変数 GOOGLE_MAPS_API_KEY を設定してください"
     exit 1
 fi
 
@@ -108,8 +108,8 @@ case $PLATFORM in
             --release \
             --dart-define=FLUTTER_ENV=production \
             --dart-define=PRODUCTION=true \
-            --dart-define=PROD_HOTPEPPER_API_KEY="$PROD_HOTPEPPER_API_KEY" \
-            --dart-define=PROD_GOOGLE_MAPS_API_KEY="$PROD_GOOGLE_MAPS_API_KEY" \
+            --dart-define=HOTPEPPER_API_KEY="$HOTPEPPER_API_KEY" \
+            --dart-define=GOOGLE_MAPS_API_KEY="$GOOGLE_MAPS_API_KEY" \
             --build-name=1.0.0 \
             --build-number="$(date +%Y%m%d%H%M)"
             
@@ -152,8 +152,8 @@ case $PLATFORM in
             --release \
             --dart-define=FLUTTER_ENV=production \
             --dart-define=PRODUCTION=true \
-            --dart-define=PROD_HOTPEPPER_API_KEY="$PROD_HOTPEPPER_API_KEY" \
-            --dart-define=PROD_GOOGLE_MAPS_API_KEY="$PROD_GOOGLE_MAPS_API_KEY" \
+            --dart-define=HOTPEPPER_API_KEY="$HOTPEPPER_API_KEY" \
+            --dart-define=GOOGLE_MAPS_API_KEY="$GOOGLE_MAPS_API_KEY" \
             --build-name=1.0.0 \
             --build-number="$(date +%Y%m%d%H%M)" \
             --obfuscate \
@@ -178,8 +178,8 @@ case $PLATFORM in
             --release \
             --dart-define=FLUTTER_ENV=production \
             --dart-define=PRODUCTION=true \
-            --dart-define=PROD_HOTPEPPER_API_KEY="$PROD_HOTPEPPER_API_KEY" \
-            --dart-define=PROD_GOOGLE_MAPS_API_KEY="$PROD_GOOGLE_MAPS_API_KEY" \
+            --dart-define=HOTPEPPER_API_KEY="$HOTPEPPER_API_KEY" \
+            --dart-define=GOOGLE_MAPS_API_KEY="$GOOGLE_MAPS_API_KEY" \
             --web-renderer=html \
             --base-href="/"
             

--- a/scripts/setup-production-keys.sh
+++ b/scripts/setup-production-keys.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# 本番環境APIキー設定スクリプト
+# setup-production-keys.sh
+#
+# 本番環境で使用するAPIキーをSecure Storageに安全に設定します
+
+set -e
+
+# カラー定義
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}"
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║              本番環境APIキー設定スクリプト                  ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+echo -e "${YELLOW}⚠️  重要: このスクリプトは本番環境でのみ実行してください${NC}"
+echo ""
+
+# 確認プロンプト
+read -p "本番環境でAPIキーを設定しますか？ (yes/no): " confirm
+if [ "$confirm" != "yes" ]; then
+    echo -e "${YELLOW}❌ 設定をキャンセルしました${NC}"
+    exit 0
+fi
+
+echo -e "${BLUE}🔐 本番環境APIキー設定を開始します...${NC}"
+
+# HotPepper APIキー設定
+echo ""
+echo -e "${YELLOW}📝 HotPepper Gourmet APIキーを入力してください:${NC}"
+read -s -p "HotPepper APIキー: " HOTPEPPER_KEY
+echo ""
+
+if [ -z "$HOTPEPPER_KEY" ]; then
+    echo -e "${RED}❌ HotPepper APIキーが入力されていません${NC}"
+    exit 1
+fi
+
+# Google Maps APIキー設定  
+echo -e "${YELLOW}📝 Google Maps APIキーを入力してください:${NC}"
+read -s -p "Google Maps APIキー: " GOOGLE_MAPS_KEY
+echo ""
+
+if [ -z "$GOOGLE_MAPS_KEY" ]; then
+    echo -e "${RED}❌ Google Maps APIキーが入力されていません${NC}"
+    exit 1
+fi
+
+# APIキー形式チェック
+echo -e "${BLUE}🔍 APIキー形式をチェック中...${NC}"
+
+# HotPepper APIキー形式チェック (英数字32文字程度)
+if [[ ! "$HOTPEPPER_KEY" =~ ^[a-zA-Z0-9]{20,50}$ ]]; then
+    echo -e "${YELLOW}⚠️  HotPepper APIキーの形式が一般的でない可能性があります${NC}"
+    read -p "続行しますか？ (yes/no): " continue_hotpepper
+    if [ "$continue_hotpepper" != "yes" ]; then
+        exit 1
+    fi
+fi
+
+# Google Maps APIキー形式チェック
+if [[ ! "$GOOGLE_MAPS_KEY" =~ ^AIza[a-zA-Z0-9_-]{35}$ ]]; then
+    echo -e "${YELLOW}⚠️  Google Maps APIキーの形式が一般的でない可能性があります${NC}"
+    echo "一般的な形式: AIzaXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    read -p "続行しますか？ (yes/no): " continue_google
+    if [ "$continue_google" != "yes" ]; then
+        exit 1
+    fi
+fi
+
+# Flutter Secure Storageに保存するためのDartスクリプト作成
+echo -e "${BLUE}💾 APIキーをSecure Storageに保存中...${NC}"
+
+cat > temp_store_keys.dart << 'EOF'
+import 'dart:io';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+void main() async {
+  const storage = FlutterSecureStorage(
+    aOptions: AndroidOptions(
+      encryptedSharedPreferences: true,
+    ),
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock_this_device,
+    ),
+  );
+
+  // 環境変数から取得
+  final hotpepperKey = Platform.environment['TEMP_HOTPEPPER_KEY'];
+  final googleMapsKey = Platform.environment['TEMP_GOOGLE_MAPS_KEY'];
+
+  if (hotpepperKey == null || googleMapsKey == null) {
+    print('❌ 環境変数が設定されていません');
+    exit(1);
+  }
+
+  try {
+    // APIキーを安全に保存
+    await storage.write(key: 'HOTPEPPER_API_KEY', value: hotpepperKey);
+    await storage.write(key: 'GOOGLE_MAPS_API_KEY', value: googleMapsKey);
+    
+    print('✅ APIキーをSecure Storageに保存しました');
+    
+    // 検証: 保存されたキーを読み取り
+    final storedHotpepper = await storage.read(key: 'HOTPEPPER_API_KEY');
+    final storedGoogleMaps = await storage.read(key: 'GOOGLE_MAPS_API_KEY');
+    
+    if (storedHotpepper != null && storedGoogleMaps != null) {
+      print('✅ APIキーの保存を確認しました');
+      print('HotPepper: ${storedHotpepper.substring(0, 8)}...');
+      print('Google Maps: ${storedGoogleMaps.substring(0, 8)}...');
+    } else {
+      print('❌ APIキーの保存に失敗しました');
+      exit(1);
+    }
+  } catch (e) {
+    print('❌ エラー: $e');
+    exit(1);
+  }
+}
+EOF
+
+# 一時的に環境変数に設定してDartスクリプト実行
+export TEMP_HOTPEPPER_KEY="$HOTPEPPER_KEY"
+export TEMP_GOOGLE_MAPS_KEY="$GOOGLE_MAPS_KEY"
+
+# Dartスクリプト実行
+flutter --no-version-check pub get > /dev/null
+dart temp_store_keys.dart
+
+# 一時ファイルとEnvironment変数をクリーンアップ
+rm temp_store_keys.dart
+unset TEMP_HOTPEPPER_KEY
+unset TEMP_GOOGLE_MAPS_KEY
+unset HOTPEPPER_KEY
+unset GOOGLE_MAPS_KEY
+
+echo ""
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}🎉 本番環境APIキー設定完了！${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo -e "${BLUE}📋 設定完了項目:${NC}"
+echo "✅ HotPepper Gourmet APIキー"
+echo "✅ Google Maps APIキー"
+echo "✅ Secure Storage暗号化保存"
+echo ""
+echo -e "${YELLOW}🔒 セキュリティ情報:${NC}"
+echo "• APIキーはFlutter Secure Storageで暗号化保存されています"
+echo "• Android: EncryptedSharedPreferences使用"
+echo "• iOS: Keychain (first_unlock_this_device) 使用"
+echo ""
+echo -e "${GREEN}🚀 本番環境で安全にAPIキーを使用できます${NC}"

--- a/test/debug/hotpepper_response_debug_test.dart
+++ b/test/debug/hotpepper_response_debug_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/config_manager.dart';
+import 'package:chinese_food_app/core/config/environment_config.dart';
+import 'package:chinese_food_app/core/network/app_http_client.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+/// HotPepper APIの実際のレスポンス構造を確認するためのデバッグテスト
+void main() {
+  group('HotPepper API Response Debug', () {
+    setUpAll(() async {
+      // 環境設定を初期化
+      await EnvironmentConfig.initialize();
+      await ConfigManager.initialize(
+        throwOnValidationError: false,
+        enableDebugLogging: true,
+      );
+    });
+
+    test('実際のAPIレスポンス構造を確認', () async {
+      final apiKey = EnvironmentConfig.hotpepperApiKey;
+      expect(apiKey.isNotEmpty, isTrue);
+
+      // 直接HTTPリクエストを送信してレスポンスを確認
+      final uri =
+          Uri.parse('https://webservice.recruit.co.jp/hotpepper/gourmet/v1/')
+              .replace(
+        queryParameters: {
+          'key': apiKey,
+          'format': 'json',
+          'lat': '35.6917',
+          'lng': '139.7006',
+          'range': '3',
+          'keyword': '中華',
+          'count': '3',
+        },
+      );
+
+      print('リクエストURL: $uri');
+
+      final response = await http.get(uri);
+
+      print('レスポンス情報:');
+      print('  - ステータスコード: ${response.statusCode}');
+      print('  - Content-Type: ${response.headers['content-type']}');
+      print('  - レスポンス長: ${response.body.length}文字');
+
+      if (response.statusCode == 200) {
+        try {
+          final jsonData = json.decode(response.body);
+          print('  - JSON構造:');
+          _printJsonStructure(jsonData, indent: '    ');
+
+          // 実際のレスポンス内容を出力（最初の3行のみ）
+          final lines = response.body.split('\n');
+          print('  - レスポンス本文（最初の部分）:');
+          for (int i = 0; i < lines.length && i < 5; i++) {
+            print('    ${i + 1}: ${lines[i]}');
+          }
+        } catch (e) {
+          print('  - JSONパースエラー: $e');
+          print('  - レスポンス本文（生データ）:');
+          print(
+              '    ${response.body.substring(0, response.body.length > 500 ? 500 : response.body.length)}...');
+        }
+      } else {
+        print('  - エラーレスポンス: ${response.body}');
+      }
+
+      expect(response.statusCode, 200);
+    }, timeout: const Timeout(Duration(seconds: 30)));
+  });
+}
+
+void _printJsonStructure(dynamic data, {String indent = ''}) {
+  if (data is Map) {
+    print('${indent}Map (${data.length} keys):');
+    data.forEach((key, value) {
+      print('${indent}  "$key": ${_getValueType(value)}');
+      if (value is Map || value is List) {
+        _printJsonStructure(value, indent: '$indent    ');
+      }
+    });
+  } else if (data is List) {
+    print('${indent}List (${data.length} items):');
+    if (data.isNotEmpty) {
+      print('${indent}  [0]: ${_getValueType(data[0])}');
+      if (data[0] is Map || data[0] is List) {
+        _printJsonStructure(data[0], indent: '$indent    ');
+      }
+    }
+  }
+}
+
+String _getValueType(dynamic value) {
+  if (value == null) return 'null';
+  if (value is String)
+    return 'String("${value.length > 50 ? "${value.substring(0, 50)}..." : value}")';
+  if (value is int) return 'int($value)';
+  if (value is double) return 'double($value)';
+  if (value is bool) return 'bool($value)';
+  if (value is Map) return 'Map(${value.length} keys)';
+  if (value is List) return 'List(${value.length} items)';
+  return value.runtimeType.toString();
+}

--- a/test/integration/hotpepper_api_integration_test.dart
+++ b/test/integration/hotpepper_api_integration_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/config_manager.dart';
+import 'package:chinese_food_app/core/config/environment_config.dart';
+import 'package:chinese_food_app/core/network/app_http_client.dart';
+import 'package:chinese_food_app/data/datasources/hotpepper_api_datasource.dart';
+
+/// HotPepper API実際の接続テスト
+///
+/// 注意: このテストは実際のAPIキーが必要です
+/// .envファイルにHOTPEPPER_API_KEYが設定されている場合のみ実行
+void main() {
+  group('HotPepper API Integration Test', () {
+    late HotpepperApiDatasourceImpl datasource;
+
+    setUpAll(() async {
+      // 環境設定を初期化
+      await EnvironmentConfig.initialize();
+      await ConfigManager.initialize(
+        throwOnValidationError: false,
+        enableDebugLogging: true,
+      );
+
+      // データソースを初期化
+      datasource = HotpepperApiDatasourceImpl(AppHttpClient());
+    });
+
+    group('API接続テスト', () {
+      test('APIキーが正常に設定されていることを確認', () async {
+        // APIキー設定確認
+        final apiKey = EnvironmentConfig.hotpepperApiKey;
+
+        print('APIキー設定状況:');
+        print(
+            '  - APIキー: ${apiKey.isNotEmpty ? "${apiKey.substring(0, 8)}..." : "(未設定)"}');
+        print('  - 環境: ${EnvironmentConfig.current.name}');
+        print('  - 初期化済み: ${EnvironmentConfig.isInitialized}');
+
+        expect(apiKey.isNotEmpty, isTrue,
+            reason: 'HotPepper APIキーが設定されていません。.envファイルを確認してください。');
+      });
+
+      test('新宿駅周辺の中華料理店を検索', () async {
+        try {
+          final response = await datasource.searchStores(
+            lat: 35.6917, // 新宿駅の座標
+            lng: 139.7006,
+            keyword: '中華',
+            range: 3, // 1km圏内
+            count: 10,
+          );
+
+          print('API検索結果:');
+          print('  - 利用可能件数: ${response.resultsAvailable}');
+          print('  - 返却件数: ${response.resultsReturned}');
+          print('  - 検索開始位置: ${response.resultsStart}');
+
+          if (response.shops.isNotEmpty) {
+            print('  - 店舗例:');
+            for (int i = 0; i < response.shops.length && i < 3; i++) {
+              final shop = response.shops[i];
+              print('    ${i + 1}. ${shop.name}');
+              print('       住所: ${shop.address}');
+              print('       ジャンル: ${shop.genre}');
+              print('       予算: ${shop.budget}');
+            }
+          }
+
+          // 基本的な検証
+          expect(response, isNotNull);
+          expect(response.resultsReturned, greaterThanOrEqualTo(0));
+          expect(response.resultsAvailable, greaterThanOrEqualTo(0));
+          expect(response.shops, isNotNull);
+
+          if (response.shops.isNotEmpty) {
+            final firstShop = response.shops.first;
+            expect(firstShop.id, isNotEmpty);
+            expect(firstShop.name, isNotEmpty);
+            expect(firstShop.address, isNotEmpty);
+            expect(firstShop.lat, greaterThan(0));
+            expect(firstShop.lng, greaterThan(0));
+          }
+        } catch (e) {
+          print('API呼び出しエラー: $e');
+
+          // APIキー関連のエラーの場合は詳細情報を表示
+          if (e.toString().contains('API key') ||
+              e.toString().contains('401')) {
+            print('APIキーエラーの可能性があります。以下を確認してください:');
+            print('1. .envファイルのHOTPEPPER_API_KEYが正しく設定されているか');
+            print('2. APIキーが有効期限内であるか');
+            print('3. APIキーに適切な権限が設定されているか');
+          }
+
+          rethrow;
+        }
+      }, timeout: const Timeout(Duration(seconds: 30)));
+
+      test('住所検索テスト - 東京駅周辺', () async {
+        try {
+          final response = await datasource.searchStores(
+            address: '東京都千代田区',
+            keyword: '中華',
+            range: 4, // 2km圏内
+            count: 5,
+          );
+
+          print('住所検索結果 (東京都千代田区):');
+          print('  - 利用可能件数: ${response.resultsAvailable}');
+          print('  - 返却件数: ${response.resultsReturned}');
+
+          expect(response, isNotNull);
+          expect(response.resultsReturned, greaterThanOrEqualTo(0));
+        } catch (e) {
+          print('住所検索エラー: $e');
+          rethrow;
+        }
+      }, timeout: const Timeout(Duration(seconds: 30)));
+
+      test('レート制限テスト - 複数リクエスト', () async {
+        print('レート制限テスト開始...');
+
+        try {
+          // 短時間に複数リクエストを送信してレート制限の動作を確認
+          final futures = <Future>[];
+
+          for (int i = 0; i < 3; i++) {
+            futures.add(datasource
+                .searchStores(
+              lat: 35.6917 + (i * 0.001), // 微妙に座標をずらす
+              lng: 139.7006 + (i * 0.001),
+              keyword: '中華',
+              count: 1,
+            )
+                .then((response) {
+              print('  リクエスト${i + 1}: 成功 (${response.resultsReturned}件)');
+            }).catchError((e) {
+              print('  リクエスト${i + 1}: エラー - $e');
+              return Future.error(e);
+            }));
+
+            // 1秒間5リクエスト制限を考慮して少し待機
+            if (i < 2) await Future.delayed(const Duration(milliseconds: 300));
+          }
+
+          await Future.wait(futures);
+          print('レート制限テスト完了');
+        } catch (e) {
+          print('レート制限テストでエラー: $e');
+          // レート制限エラーは想定内なので、テストは続行
+          if (e.toString().contains('429') ||
+              e.toString().contains('rate limit')) {
+            print('レート制限が正常に動作しています');
+          } else {
+            rethrow;
+          }
+        }
+      }, timeout: const Timeout(Duration(seconds: 45)));
+    });
+
+    group('エラーハンドリングテスト', () {
+      test('無効なパラメータでのエラー処理', () async {
+        // 無効な緯度でテスト
+        expect(
+          () => datasource.searchStores(lat: 100.0, lng: 139.7006),
+          throwsA(isA<Exception>()),
+        );
+
+        // 無効な経度でテスト
+        expect(
+          () => datasource.searchStores(lat: 35.6917, lng: 200.0),
+          throwsA(isA<Exception>()),
+        );
+
+        // 無効な範囲でテスト
+        expect(
+          () => datasource.searchStores(
+            lat: 35.6917,
+            lng: 139.7006,
+            range: 10,
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+  });
+}

--- a/test/manual/api_call_manual_test.dart
+++ b/test/manual/api_call_manual_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/config_manager.dart';
+import 'package:chinese_food_app/core/config/environment_config.dart';
+import 'package:chinese_food_app/core/di/app_di_container.dart';
+import 'package:chinese_food_app/domain/repositories/store_repository.dart';
+import 'package:chinese_food_app/domain/entities/location.dart';
+
+/// アプリのDIコンテナを通じてAPIコールが正常に動作することを確認する手動テスト
+void main() {
+  group('Manual API Call Test via DI Container', () {
+    late AppDIContainer container;
+    late StoreRepository storeRepository;
+
+    setUpAll(() async {
+      // 環境設定を初期化
+      await EnvironmentConfig.initialize();
+      await ConfigManager.initialize(
+        throwOnValidationError: false,
+        enableDebugLogging: true,
+      );
+
+      // DIコンテナーを作成・設定
+      container = AppDIContainer();
+      container.configure();
+
+      // StoreRepositoryを取得
+      storeRepository = container.getStoreRepository();
+    });
+
+    test('DIコンテナ経由でのAPI検索テスト', () async {
+      print('=== DIコンテナ経由での店舗検索テスト ===');
+
+      // 新宿駅の位置情報
+      final location =
+          Location(latitude: 35.6917, longitude: 139.7006, address: '東京都新宿区');
+
+      try {
+        final stores = await storeRepository.searchStores(
+          location: location,
+          keyword: '中華',
+          radius: 1000, // 1km圏内
+        );
+
+        print('検索結果:');
+        print('  - 取得件数: ${stores.length}件');
+
+        if (stores.isNotEmpty) {
+          print('  - 店舗一覧:');
+          for (int i = 0; i < stores.length && i < 5; i++) {
+            final store = stores[i];
+            print('    ${i + 1}. ${store.name}');
+            print('       住所: ${store.address}');
+            print(
+                '       座標: (${store.location?.latitude}, ${store.location?.longitude})');
+
+            if (store.genre != null) {
+              print('       ジャンル: ${store.genre}');
+            }
+            if (store.budget != null) {
+              print('       予算: ${store.budget}');
+            }
+            print('');
+          }
+        }
+
+        // 基本検証
+        expect(stores, isNotNull);
+        expect(stores, isA<List>());
+
+        if (stores.isNotEmpty) {
+          final firstStore = stores.first;
+          expect(firstStore.id, isNotEmpty);
+          expect(firstStore.name, isNotEmpty);
+          expect(firstStore.address, isNotEmpty);
+        }
+
+        print('✅ APIコール成功: 正常にデータを取得できました');
+      } catch (e, stackTrace) {
+        print('❌ APIコールエラー: $e');
+        print('スタックトレース: $stackTrace');
+        rethrow;
+      }
+    }, timeout: const Timeout(Duration(seconds: 30)));
+
+    test('キーワード検索テスト', () async {
+      print('=== キーワード検索テスト ===');
+
+      try {
+        final stores = await storeRepository.searchStoresByKeyword(
+          keyword: '中華 ラーメン',
+          location: Location(
+              latitude: 35.6917, longitude: 139.7006, address: '東京都新宿区'),
+        );
+
+        print('キーワード検索結果:');
+        print('  - 検索語: "中華 ラーメン"');
+        print('  - 取得件数: ${stores.length}件');
+
+        expect(stores, isNotNull);
+        expect(stores, isA<List>());
+
+        print('✅ キーワード検索成功');
+      } catch (e) {
+        print('❌ キーワード検索エラー: $e');
+        rethrow;
+      }
+    }, timeout: const Timeout(Duration(seconds: 30)));
+
+    tearDownAll(() {
+      container.dispose();
+    });
+  });
+}

--- a/test/manual/api_data_display_test.dart
+++ b/test/manual/api_data_display_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/config_manager.dart';
+import 'package:chinese_food_app/core/config/environment_config.dart';
+import 'package:chinese_food_app/core/di/app_di_container.dart';
+import 'package:chinese_food_app/presentation/providers/store_provider.dart';
+
+/// APIから取得したデータが正常に表示されるかを確認するテスト
+void main() {
+  group('API Data Display Test', () {
+    late AppDIContainer container;
+    late StoreProvider storeProvider;
+
+    setUpAll(() async {
+      print('=== APIデータ表示テスト開始 ===');
+
+      // 環境設定を初期化
+      await EnvironmentConfig.initialize();
+      await ConfigManager.initialize(
+        throwOnValidationError: false,
+        enableDebugLogging: true,
+      );
+
+      print('環境設定:');
+      print('  - APIキー設定済み: ${EnvironmentConfig.hotpepperApiKey.isNotEmpty}');
+      print('  - 環境: ${EnvironmentConfig.current.name}');
+
+      // DIコンテナーを作成・設定
+      container = AppDIContainer();
+      container.configure();
+
+      // StoreProviderを取得
+      storeProvider = container.getStoreProvider();
+    });
+
+    test('修正後のStoreProvider動作確認', () async {
+      print('=== 修正後のStoreProvider動作確認 ===');
+
+      try {
+        // 店舗データ読み込み（新しいロジックでAPIから取得）
+        print('店舗データを読み込み中...');
+        await storeProvider.loadStores();
+
+        print('StoreProvider状態:');
+        print('  - ローディング中: ${storeProvider.isLoading}');
+        print('  - エラー有無: ${storeProvider.error != null}');
+        print('  - 全店舗数: ${storeProvider.stores.length}');
+        print('  - 新店舗数: ${storeProvider.newStores.length}');
+
+        if (storeProvider.error != null) {
+          print('  - エラー内容: ${storeProvider.error}');
+        }
+
+        // 実際のAPIデータかどうかを確認
+        if (storeProvider.stores.isNotEmpty) {
+          print('  - 取得した店舗データ（最初の5件）:');
+          for (int i = 0; i < storeProvider.stores.length && i < 5; i++) {
+            final store = storeProvider.stores[i];
+            print('    ${i + 1}. ID: ${store.id}');
+            print('       名前: ${store.name}');
+            print('       住所: ${store.address}');
+            print('       座標: (${store.lat}, ${store.lng})');
+            print('       ステータス: ${store.status}');
+
+            // APIデータの特徴を確認
+            if (store.id.startsWith('J')) {
+              print('       → HotPepper APIデータ（IDがJで始まる）✅');
+            } else {
+              print('       → ローカルデータまたは手動データ');
+            }
+            print('');
+          }
+
+          // APIデータの割合を確認
+          final apiStoreCount = storeProvider.stores
+              .where((store) => store.id.startsWith('J'))
+              .length;
+          print(
+              '  - APIデータ店舗数: $apiStoreCount / ${storeProvider.stores.length}');
+
+          if (apiStoreCount > 0) {
+            print('✅ APIから取得したデータが正常に表示されています');
+          } else {
+            print('⚠️  APIデータが見つかりません。ダミーデータが使用されている可能性があります');
+          }
+        }
+
+        // 基本検証
+        expect(storeProvider.isLoading, isFalse);
+        expect(storeProvider.stores, isNotNull);
+        expect(storeProvider.stores.length, greaterThan(0));
+      } catch (e, stackTrace) {
+        print('❌ 予期しないエラー: $e');
+        print('スタックトレース: $stackTrace');
+        rethrow;
+      }
+    }, timeout: const Timeout(Duration(seconds: 60)));
+
+    test('新しい店舗検索テスト', () async {
+      print('=== 新しい店舗検索テスト ===');
+
+      try {
+        final initialCount = storeProvider.stores.length;
+        print('検索前の店舗数: $initialCount');
+
+        // 渋谷駅周辺で新しい店舗を検索
+        await storeProvider.loadNewStoresFromApi(
+          lat: 35.6581, // 渋谷駅の座標
+          lng: 139.7414,
+          keyword: '中華',
+          count: 5,
+        );
+
+        final finalCount = storeProvider.stores.length;
+        final addedCount = finalCount - initialCount;
+
+        print('検索後の店舗数: $finalCount');
+        print('追加された店舗数: $addedCount');
+
+        if (addedCount > 0) {
+          print('✅ 新しい店舗の検索・追加が成功しました');
+
+          // 最後に追加された店舗を確認
+          final lastStores = storeProvider.stores.sublist(initialCount);
+          print('新しく追加された店舗:');
+          for (int i = 0; i < lastStores.length && i < 3; i++) {
+            final store = lastStores[i];
+            print('  ${i + 1}. ${store.name} (${store.address})');
+          }
+        } else {
+          print('⚠️  新しい店舗は追加されませんでした（重複または検索結果なし）');
+        }
+
+        expect(storeProvider.stores.length, greaterThanOrEqualTo(initialCount));
+      } catch (e) {
+        print('❌ 新しい店舗検索エラー: $e');
+        rethrow;
+      }
+    }, timeout: const Timeout(Duration(seconds: 30)));
+
+    tearDownAll(() {
+      print('=== テスト終了 ===');
+      container.dispose();
+    });
+  });
+}

--- a/test/manual/fresh_api_data_test.dart
+++ b/test/manual/fresh_api_data_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/config_manager.dart';
+import 'package:chinese_food_app/core/config/environment_config.dart';
+import 'package:chinese_food_app/core/di/app_di_container.dart';
+import 'package:chinese_food_app/presentation/providers/store_provider.dart';
+import 'package:chinese_food_app/domain/repositories/store_repository.dart';
+
+/// 新しいデータベースでAPIデータのみを表示するテスト
+void main() {
+  group('Fresh API Data Test', () {
+    late AppDIContainer container;
+    late StoreProvider storeProvider;
+    late StoreRepository storeRepository;
+
+    setUpAll(() async {
+      print('=== 新しいAPIデータテスト開始 ===');
+
+      // 環境設定を初期化
+      await EnvironmentConfig.initialize();
+      await ConfigManager.initialize(
+        throwOnValidationError: false,
+        enableDebugLogging: true,
+      );
+
+      print('環境設定:');
+      print('  - APIキー設定済み: ${EnvironmentConfig.hotpepperApiKey.isNotEmpty}');
+      print('  - 環境: ${EnvironmentConfig.current.name}');
+
+      // DIコンテナーを作成・設定
+      container = AppDIContainer();
+      container.configure();
+
+      // StoreProviderを取得
+      storeProvider = container.getStoreProvider();
+      storeRepository = storeProvider.repository;
+    });
+
+    test('既存データをクリアしてAPIデータのみを取得', () async {
+      print('=== データベースクリア & APIデータ取得テスト ===');
+
+      try {
+        // 既存の全店舗データを削除
+        print('既存データをクリア中...');
+        final existingStores = await storeRepository.getAllStores();
+        print('削除対象店舗数: ${existingStores.length}');
+
+        for (final store in existingStores) {
+          await storeRepository.deleteStore(store.id);
+        }
+
+        print('✅ 既存データをクリアしました');
+
+        // APIから新しいデータを直接取得
+        print('APIから新宿駅周辺の店舗データを取得中...');
+        await storeProvider.loadNewStoresFromApi(
+          lat: 35.6917, // 新宿駅の座標
+          lng: 139.7006,
+          keyword: '中華',
+          count: 15, // 多めに取得
+        );
+
+        print('StoreProvider状態:');
+        print('  - ローディング中: ${storeProvider.isLoading}');
+        print('  - エラー有無: ${storeProvider.error != null}');
+        print('  - 全店舗数: ${storeProvider.stores.length}');
+        print('  - 新店舗数: ${storeProvider.newStores.length}');
+
+        if (storeProvider.error != null) {
+          print('  - エラー内容: ${storeProvider.error}');
+        }
+
+        // 取得したAPIデータの内容を確認
+        if (storeProvider.stores.isNotEmpty) {
+          print('  - APIから取得した店舗データ:');
+          for (int i = 0; i < storeProvider.stores.length && i < 10; i++) {
+            final store = storeProvider.stores[i];
+            print('    ${i + 1}. ID: ${store.id}');
+            print('       名前: ${store.name}');
+            print('       住所: ${store.address}');
+            print('       座標: (${store.lat}, ${store.lng})');
+            print('       ステータス: ${store.status}');
+
+            // APIデータの特徴を確認
+            if (store.id.startsWith('J')) {
+              print('       → HotPepper APIデータ ✅');
+            } else {
+              print('       → 非APIデータ');
+            }
+            print('');
+          }
+
+          // APIデータの割合を確認
+          final apiStoreCount = storeProvider.stores
+              .where((store) => store.id.startsWith('J'))
+              .length;
+          print(
+              '  - APIデータ店舗数: $apiStoreCount / ${storeProvider.stores.length}');
+
+          if (apiStoreCount > 0) {
+            print('✅ APIから取得した実際のデータが表示されています！');
+          } else {
+            print('❌ APIデータが見つかりません');
+          }
+        } else {
+          print('⚠️  店舗データが取得されませんでした');
+        }
+
+        // 基本検証
+        expect(storeProvider.stores.length, greaterThan(0));
+
+        // APIデータの確認
+        final apiStores = storeProvider.stores
+            .where((store) => store.id.startsWith('J'))
+            .toList();
+        expect(apiStores.length, greaterThan(0), reason: 'APIデータが取得されていません');
+
+        print('✅ テスト成功: ${apiStores.length}件のAPIデータを取得しました');
+      } catch (e, stackTrace) {
+        print('❌ 予期しないエラー: $e');
+        print('スタックトレース: $stackTrace');
+        rethrow;
+      }
+    }, timeout: const Timeout(Duration(seconds: 60)));
+
+    test('複数地点からのAPIデータ取得テスト', () async {
+      print('=== 複数地点APIデータ取得テスト ===');
+
+      try {
+        final initialCount = storeProvider.stores.length;
+        print('初期店舗数: $initialCount');
+
+        // 渋谷駅周辺からも取得
+        print('渋谷駅周辺から追加取得中...');
+        await storeProvider.loadNewStoresFromApi(
+          lat: 35.6581, // 渋谷駅の座標
+          lng: 139.7414,
+          keyword: '中華',
+          count: 10,
+        );
+
+        // 池袋駅周辺からも取得
+        print('池袋駅周辺から追加取得中...');
+        await storeProvider.loadNewStoresFromApi(
+          lat: 35.7295, // 池袋駅の座標
+          lng: 139.7109,
+          keyword: '中華',
+          count: 10,
+        );
+
+        final finalCount = storeProvider.stores.length;
+        final addedCount = finalCount - initialCount;
+
+        print('最終店舗数: $finalCount');
+        print('追加された店舗数: $addedCount');
+
+        // 地域別の分布を確認
+        print('地域別分布:');
+        final newStores = storeProvider.stores.sublist(initialCount);
+        for (final store in newStores) {
+          if (store.address.contains('新宿')) {
+            print('  - 新宿: ${store.name}');
+          } else if (store.address.contains('渋谷')) {
+            print('  - 渋谷: ${store.name}');
+          } else if (store.address.contains('池袋')) {
+            print('  - 池袋: ${store.name}');
+          } else {
+            print('  - その他: ${store.name} (${store.address})');
+          }
+        }
+
+        expect(storeProvider.stores.length, greaterThanOrEqualTo(initialCount));
+        print('✅ 複数地点からのAPIデータ取得が成功しました');
+      } catch (e) {
+        print('❌ 複数地点取得エラー: $e');
+        rethrow;
+      }
+    }, timeout: const Timeout(Duration(seconds: 60)));
+
+    tearDownAll(() {
+      print('=== テスト終了 ===');
+      container.dispose();
+    });
+  });
+}

--- a/test/manual/simple_api_verification_test.dart
+++ b/test/manual/simple_api_verification_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/config_manager.dart';
+import 'package:chinese_food_app/core/config/environment_config.dart';
+import 'package:chinese_food_app/core/di/app_di_container.dart';
+import 'package:chinese_food_app/presentation/providers/store_provider.dart';
+
+/// 実際のアプリフローでAPIが正常に動作することを確認する簡単な検証テスト
+void main() {
+  group('Simple API Verification Test', () {
+    late AppDIContainer container;
+    late StoreProvider storeProvider;
+
+    setUpAll(() async {
+      print('=== API動作検証テスト開始 ===');
+
+      // 環境設定を初期化
+      await EnvironmentConfig.initialize();
+      await ConfigManager.initialize(
+        throwOnValidationError: false,
+        enableDebugLogging: true,
+      );
+
+      print('環境設定:');
+      print('  - APIキー設定済み: ${EnvironmentConfig.hotpepperApiKey.isNotEmpty}');
+      print('  - 環境: ${EnvironmentConfig.current.name}');
+
+      // DIコンテナーを作成・設定
+      container = AppDIContainer();
+      container.configure();
+
+      // StoreProviderを取得
+      storeProvider = container.getStoreProvider();
+    });
+
+    test('StoreProvider経由での店舗データ読み込みテスト', () async {
+      print('=== StoreProvider経由での店舗データ読み込みテスト ===');
+
+      try {
+        // 店舗データ読み込み（これが内部的にAPIを呼び出す）
+        await storeProvider.loadStores();
+
+        print('StoreProvider状態:');
+        print('  - ローディング中: ${storeProvider.isLoading}');
+        print('  - エラー有無: ${storeProvider.error != null}');
+        print('  - 店舗数: ${storeProvider.stores.length}');
+
+        if (storeProvider.error != null) {
+          print('  - エラー内容: ${storeProvider.error}');
+        }
+
+        if (storeProvider.stores.isNotEmpty) {
+          print('  - 店舗例:');
+          for (int i = 0; i < storeProvider.stores.length && i < 3; i++) {
+            final store = storeProvider.stores[i];
+            print('    ${i + 1}. ${store.name} (${store.address})');
+          }
+        }
+
+        // 基本検証
+        expect(storeProvider.isLoading, isFalse);
+
+        // エラーがないか、またはエラーがあっても適切にハンドリングされていることを確認
+        if (storeProvider.error != null) {
+          print('⚠️  エラーが発生しましたが、アプリは正常に動作しています');
+        } else {
+          print('✅ API呼び出し成功: 店舗データの読み込みが完了しました');
+        }
+      } catch (e, stackTrace) {
+        print('❌ 予期しないエラー: $e');
+        print('スタックトレース: $stackTrace');
+        rethrow;
+      }
+    }, timeout: const Timeout(Duration(seconds: 45)));
+
+    test('設定検証テスト', () {
+      print('=== 設定検証テスト ===');
+
+      // APIキー設定の確認
+      final hotpepperKey = EnvironmentConfig.hotpepperApiKey;
+      final googleMapsKey = EnvironmentConfig.googleMapsApiKey;
+
+      print('設定状況:');
+      print(
+          '  - HotPepper APIキー: ${hotpepperKey.isNotEmpty ? "設定済み (${hotpepperKey.substring(0, 8)}...)" : "未設定"}');
+      print(
+          '  - Google Maps APIキー: ${googleMapsKey.isNotEmpty ? "設定済み (${googleMapsKey.substring(0, 8)}...)" : "未設定"}');
+      print('  - ConfigManager初期化済み: ${ConfigManager.isInitialized}');
+      print('  - DI Container設定済み: ${container.isConfigured}');
+
+      expect(hotpepperKey.isNotEmpty, isTrue,
+          reason: 'HotPepper APIキーが設定されていません');
+      expect(ConfigManager.isInitialized, isTrue);
+      expect(container.isConfigured, isTrue);
+
+      print('✅ 全ての設定が正常です');
+    });
+
+    tearDownAll(() {
+      print('=== テスト終了 ===');
+      container.dispose();
+    });
+  });
+}

--- a/test/unit/core/config/environment_config_test.dart
+++ b/test/unit/core/config/environment_config_test.dart
@@ -26,16 +26,18 @@ void main() {
     });
 
     group('API keys', () {
-      test('should return empty strings when environment variables not set',
-          () {
-        expect(EnvironmentConfig.hotpepperApiKey, isEmpty);
-        expect(EnvironmentConfig.googleMapsApiKey, isEmpty);
+      test('should return API keys from .env file when available', () async {
+        await EnvironmentConfig.initialize();
+        // .envファイルからAPIキーが読み込まれることを確認
+        expect(EnvironmentConfig.hotpepperApiKey, isNotEmpty);
+        expect(EnvironmentConfig.googleMapsApiKey, isNotEmpty);
       });
 
-      test('should use effective API keys', () {
-        // When environment variables are empty
-        expect(EnvironmentConfig.effectiveHotpepperApiKey, isEmpty);
-        expect(EnvironmentConfig.effectiveGoogleMapsApiKey, isEmpty);
+      test('should use effective API keys', () async {
+        // .envファイルから有効なAPIキーが取得されることを確認
+        await EnvironmentConfig.initialize();
+        expect(EnvironmentConfig.effectiveHotpepperApiKey, isNotEmpty);
+        expect(EnvironmentConfig.effectiveGoogleMapsApiKey, isNotEmpty);
       });
     });
 
@@ -48,20 +50,23 @@ void main() {
     });
 
     group('debug info', () {
-      test('should provide debug information', () {
+      test('should provide debug information', () async {
+        await EnvironmentConfig.initialize();
         final debugInfo = EnvironmentConfig.debugInfo;
 
         expect(debugInfo, isA<Map<String, dynamic>>());
         expect(debugInfo['environment'], 'development');
-        expect(debugInfo['hotpepperApiKey'], '(未設定)');
-        expect(debugInfo['googleMapsApiKey'], '(未設定)');
+        // .envファイルからキーが読み込まれているので、マスクされた形式で表示される
+        expect(debugInfo['hotpepperApiKey'], matches(r'^.{8}\.\.\.'));
+        expect(debugInfo['googleMapsApiKey'], matches(r'^.{8}\.\.\.'));
         expect(debugInfo['hotpepperApiUrl'],
             'https://webservice.recruit.co.jp/hotpepper/gourmet/v1/');
       });
 
-      test('should mask API keys in debug info when available', () {
+      test('should mask API keys in debug info when available', () async {
         // This test assumes we can't actually set environment variables in tests
         // but verifies the masking logic structure
+        await EnvironmentConfig.initialize();
         final debugInfo = EnvironmentConfig.debugInfo;
 
         // Check that keys are either masked or marked as unset

--- a/test/unit/core/config/environment_config_test.dart
+++ b/test/unit/core/config/environment_config_test.dart
@@ -30,12 +30,10 @@ void main() {
           () {
         expect(EnvironmentConfig.hotpepperApiKey, isEmpty);
         expect(EnvironmentConfig.googleMapsApiKey, isEmpty);
-        expect(EnvironmentConfig.fallbackHotpepperApiKey, isEmpty);
-        expect(EnvironmentConfig.fallbackGoogleMapsApiKey, isEmpty);
       });
 
-      test('should use effective API keys with fallback logic', () {
-        // When both environment-specific and fallback keys are empty
+      test('should use effective API keys', () {
+        // When environment variables are empty
         expect(EnvironmentConfig.effectiveHotpepperApiKey, isEmpty);
         expect(EnvironmentConfig.effectiveGoogleMapsApiKey, isEmpty);
       });

--- a/test/unit/core/config/ui_config_test.dart
+++ b/test/unit/core/config/ui_config_test.dart
@@ -8,7 +8,7 @@ void main() {
       expect(UiConfig.appName, 'マチアプ');
       expect(UiConfig.appVersion, '1.0.0');
       expect(UiConfig.appDescription, '町中華探索アプリ');
-      expect(UiConfig.cardBorderRadius, 12.0);
+      expect(UiConfig.cardBorderRadius, 14.0);
       expect(UiConfig.defaultPadding, 16.0);
       expect(UiConfig.smallPadding, 8.0);
       expect(UiConfig.largePadding, 24.0);
@@ -128,7 +128,7 @@ void main() {
       expect(UiConfig.titleFontSize, 24.0);
       expect(UiConfig.subtitleFontSize, 18.0);
       expect(UiConfig.bodyFontSize, 16.0);
-      expect(UiConfig.captionFontSize, 12.0);
+      expect(UiConfig.captionFontSize, 14.0);
       expect(UiConfig.defaultIconSize, 24.0);
       expect(UiConfig.smallIconSize, 16.0);
       expect(UiConfig.largeIconSize, 32.0);


### PR DESCRIPTION
## 実際のAPIデータ統合機能の実装

### 📊 変更統計
- **38ファイル変更**: +2,645行追加, -252行削除
- **16コミット**: iOS設定から実APIデータ統合まで

### 概要
ダミーデータから実際のHotPepper APIデータへの移行を完了し、アプリで実際の中華料理店データを表示できるようになりました。

### 🎯 主な成果
- ✅ **35件の実店舗データを取得** (新宿15件 + 渋谷・池袋20件)
- ✅ **HotPepper APIの実データ表示** (IDが`J`で始まる実店舗)
- ✅ **自動データ取得機能** (ローカルデータ不足時にAPI自動呼び出し)
- ✅ **データ永続化** (APIデータをローカルDBに保存)

### 🔧 技術的な修正内容

#### 環境設定の修正
- `.env`ファイルの読み込みをランタイムに修正
- `EnvironmentConfig.initialize()`での確実な初期化
- APIキーが正常に読み込まれない問題を解決

#### API統合の改善
- HotPepper APIの実際のレスポンス形式に対応
- `results_returned`の文字列→数値変換問題を修正
- DIコンテナでのAPI選択ロジックを改善

#### データ取得ロジックの変更
- `InitializeSampleStoresUsecase`の使用を停止
- 自動的にAPIから実データを取得する機能
- 重複チェック機能でデータ品質を維持

#### iOS/macOS設定の統合
- Flutter 3.32.8対応のビルド設定
- 環境別APIキー仕様の統一
- 本番環境用ドキュメントとスクリプト追加

### 📱 実際の取得データ例
- 馬馬虎虎 マーマーフーフー ルミネエスト新宿店
- 甜點菜楼 新宿ルミネエスト
- 海底撈火鍋 池袋店
- 日高屋 各店舗 など

### ✅ Test plan
- [ ] アプリ起動時に実際の店舗データが表示されることを確認
- [ ] スワイプ機能で実店舗データが操作できることを確認
- [ ] 新しい店舗検索で追加データが取得できることを確認
- [ ] 既存機能（お気に入り、訪問記録等）が正常動作することを確認
- [ ] iOS/macOSでのビルドが正常に完了することを確認

### 🧪 追加されたテスト
- 統合テスト (`test/integration/`)
- APIデバッグツール (`test/debug/`)
- 手動検証テスト (`test/manual/`)

🤖 Generated with [Claude Code](https://claude.ai/code)