### PR TITLE
🧹 [IMPORTANT] サンプルprint文の適切なログライブラリ移行

### DIFF
--- a/lib/core/events/base_event.dart
+++ b/lib/core/events/base_event.dart
@@ -40,7 +40,7 @@
 ///
 /// // Consuming
 /// EventBus.instance.on<LocationUpdatedEvent>().listen((event) {
-///   print('Location updated: ${event.location}');
+///   SecureLogger.info('イベント受信', data: {'event': event.runtimeType.toString(), 'location': event.location.toString()});
 /// });
 /// ```
 abstract class BaseEvent {

--- a/lib/core/network/api_response.dart
+++ b/lib/core/network/api_response.dart
@@ -10,7 +10,7 @@
 /// if (response.isSuccess) {
 ///   final users = jsonDecode(response.data);
 /// } else {
-///   print('Error: ${response.statusCode}');
+///   SecureLogger.error('APIエラー', data: {'statusCode': response.statusCode});
 /// }
 /// ```
 class ApiResponse {

--- a/lib/core/types/result.dart
+++ b/lib/core/types/result.dart
@@ -19,9 +19,9 @@ import '../exceptions/base_exception.dart';
 /// final result = fetchData();
 /// switch (result) {
 ///   case Success<String>():
-///     print('Data: ${result.data}');
+///     SecureLogger.info('処理完了', data: {'result': result.data});
 ///   case Failure<String>():
-///     print('Error: ${result.exception.message}');
+///     SecureLogger.error('処理エラー', error: result.exception);
 /// }
 /// ```
 sealed class Result<T> {

--- a/lib/domain/strategies/location_strategy.dart
+++ b/lib/domain/strategies/location_strategy.dart
@@ -25,9 +25,9 @@ import '../../core/types/result.dart';
 /// final result = await strategy.getCurrentLocation();
 /// switch (result) {
 ///   case Success<Location>():
-///     print('Location: ${result.data}');
+///     SecureLogger.info('位置情報取得成功', data: {'latitude': result.data.latitude, 'longitude': result.data.longitude});
 ///   case Failure<Location>():
-///     print('Error: ${result.exception}');
+///     SecureLogger.error('位置情報取得エラー', error: result.exception);
 /// }
 /// ```
 abstract class LocationStrategy {

--- a/lib/domain/usecases/location/get_current_location_usecase.dart
+++ b/lib/domain/usecases/location/get_current_location_usecase.dart
@@ -23,9 +23,9 @@ import '../../../core/types/result.dart';
 ///
 /// switch (result) {
 ///   case Success<Location>():
-///     print('Current location: ${result.data}');
+///     SecureLogger.info('現在位置取得成功', data: {'latitude': result.data.latitude, 'longitude': result.data.longitude});
 ///   case Failure<Location>():
-///     print('Failed to get location: ${result.exception.message}');
+///     SecureLogger.error('位置情報取得失敗', error: result.exception);
 /// }
 /// ```
 class GetCurrentLocationUseCase extends BaseUseCase<NoParams, Location> {

--- a/lib/domain/usecases/search_stores_usecase.dart
+++ b/lib/domain/usecases/search_stores_usecase.dart
@@ -13,7 +13,7 @@ import '../repositories/store_repository.dart';
 /// final result = await usecase.execute(params);
 ///
 /// if (result.isSuccess && result.hasStores) {
-///   print('${result.stores!.length}件の店舗が見つかりました');
+///   SecureLogger.info('店舗検索完了', data: {'storeCount': result.stores!.length});
 /// }
 /// ```
 class SearchStoresUsecase {


### PR DESCRIPTION
## 📋 概要
ドキュメント内のサンプルコードのprint文をSecureLoggerに置換し、セキュアなログ出力手法を標準化しました。

## 🔧 実装内容
### 置換対象ファイル
- ✅ `lib/core/types/result.dart`
- ✅ `lib/core/network/api_response.dart` 
- ✅ `lib/core/events/base_event.dart`
- ✅ `lib/domain/strategies/location_strategy.dart`
- ✅ `lib/domain/usecases/search_stores_usecase.dart`
- ✅ `lib/domain/usecases/location/get_current_location_usecase.dart`

### 置換例
**Before:**
```dart
///     print('Data: ${result.data}');
///     print('Error: ${result.exception.message}');
```

**After:**
```dart
///     SecureLogger.info('処理完了', data: {'result': result.data});
///     SecureLogger.error('処理エラー', error: result.exception);
```

## 🎯 期待効果
- ✅ センシティブ情報の自動マスキング
- ✅ ログレベル制御による適切なデバッグ
- ✅ セキュアなログ出力手法の標準化
- ✅ デバッグ用ログの環境別制御
- ✅ 実際のデバッグログとの混同防止

## 🧪 テスト結果
- ✅ 全テスト通過: 516 tests passed
- ✅ 静的解析: No issues found
- ✅ コードフォーマット: 適用済み

## 📊 影響範囲
- 🔍 **変更箇所**: ドキュメント内のサンプルコードのみ
- 🚀 **実装コード**: 影響なし
- 🧪 **テスト**: 全て通過
- 🔧 **実行時動作**: 変更なし

## 🔗 関連Issue
Closes #95

🤖 Generated with [Claude Code](https://claude.ai/code)