### PR TITLE
fix: バックエンドAPI接続問題の修正と診断機能追加 (Issue #185)

### DIFF
--- a/lib/core/config/api_connection_tester.dart
+++ b/lib/core/config/api_connection_tester.dart
@@ -1,0 +1,259 @@
+import 'dart:developer' as developer;
+import 'dart:io';
+import 'package:chinese_food_app/core/config/app_config.dart';
+import 'package:chinese_food_app/core/config/api_diagnostics.dart';
+import 'package:chinese_food_app/core/network/app_http_client.dart';
+
+/// API接続テスト結果
+class ApiConnectionTestResult {
+  final String testType;
+  final bool isSuccessful;
+  final String? errorMessage;
+  final Duration duration;
+  final Map<String, dynamic> details;
+
+  const ApiConnectionTestResult({
+    required this.testType,
+    required this.isSuccessful,
+    this.errorMessage,
+    required this.duration,
+    this.details = const {},
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'testType': testType,
+      'isSuccessful': isSuccessful,
+      'errorMessage': errorMessage,
+      'duration': duration.inMilliseconds,
+      'details': details,
+    };
+  }
+
+  @override
+  String toString() {
+    final status = isSuccessful ? '✅' : '❌';
+    final error = errorMessage != null ? ' - $errorMessage' : '';
+    return '$status $testType (${duration.inMilliseconds}ms)$error';
+  }
+}
+
+/// API接続テスト機能
+class ApiConnectionTester {
+  static final _httpClient = AppHttpClient();
+
+  /// 基本的な接続テスト
+  static Future<ApiConnectionTestResult> testBasicConnectivity() async {
+    final stopwatch = Stopwatch()..start();
+
+    try {
+      developer.log('🔍 基本接続テストを開始', name: 'ApiConnectionTester');
+
+      // DNS解決テスト
+      final addresses =
+          await InternetAddress.lookup('webservice.recruit.co.jp');
+      if (addresses.isEmpty) {
+        throw Exception('DNS解決に失敗しました');
+      }
+
+      stopwatch.stop();
+
+      return ApiConnectionTestResult(
+        testType: 'basic_connectivity',
+        isSuccessful: true,
+        duration: stopwatch.elapsed,
+        details: {
+          'dns_resolved': true,
+          'ip_addresses': addresses.map((a) => a.address).toList(),
+        },
+      );
+    } catch (e) {
+      stopwatch.stop();
+
+      return ApiConnectionTestResult(
+        testType: 'basic_connectivity',
+        isSuccessful: false,
+        errorMessage: e.toString(),
+        duration: stopwatch.elapsed,
+      );
+    }
+  }
+
+  /// APIキー検証テスト
+  static Future<ApiConnectionTestResult> testApiKeyValidation() async {
+    final stopwatch = Stopwatch()..start();
+
+    try {
+      developer.log('🔍 APIキー検証テストを開始', name: 'ApiConnectionTester');
+
+      // 初期化確認
+      if (!AppConfig.isInitialized) {
+        await AppConfig.initialize();
+      }
+
+      // APIキー取得試行
+      final apiKey = await AppConfig.hotpepperApiKey;
+
+      if (apiKey == null || apiKey.isEmpty) {
+        throw Exception('APIキーが設定されていません');
+      }
+
+      if (apiKey.length < 8) {
+        throw Exception('APIキーの形式が不正です');
+      }
+
+      stopwatch.stop();
+
+      return ApiConnectionTestResult(
+        testType: 'api_key_validation',
+        isSuccessful: true,
+        duration: stopwatch.elapsed,
+        details: {
+          'api_key_length': apiKey.length,
+          'api_key_prefix': apiKey.substring(0, 4),
+        },
+      );
+    } catch (e) {
+      stopwatch.stop();
+
+      return ApiConnectionTestResult(
+        testType: 'api_key_validation',
+        isSuccessful: false,
+        errorMessage: e.toString(),
+        duration: stopwatch.elapsed,
+      );
+    }
+  }
+
+  /// 設定検証テスト
+  static Future<ApiConnectionTestResult> testConfigValidation() async {
+    final stopwatch = Stopwatch()..start();
+
+    try {
+      developer.log('🔍 設定検証テストを開始', name: 'ApiConnectionTester');
+
+      final diagnostics = await ApiDiagnostics.getComprehensiveDiagnostics();
+
+      if (!diagnostics.isConfigValid) {
+        throw Exception('設定に問題があります: ${diagnostics.issues.join(', ')}');
+      }
+
+      stopwatch.stop();
+
+      return ApiConnectionTestResult(
+        testType: 'config_validation',
+        isSuccessful: true,
+        duration: stopwatch.elapsed,
+        details: {
+          'environment': diagnostics.environment,
+          'security_mode': diagnostics.securityMode,
+          'initialization_status': diagnostics.initializationStatus,
+        },
+      );
+    } catch (e) {
+      stopwatch.stop();
+
+      return ApiConnectionTestResult(
+        testType: 'config_validation',
+        isSuccessful: false,
+        errorMessage: e.toString(),
+        duration: stopwatch.elapsed,
+      );
+    }
+  }
+
+  /// HotPepper API実際の通信テスト（オプション）
+  static Future<ApiConnectionTestResult> testActualApiCall() async {
+    final stopwatch = Stopwatch()..start();
+
+    try {
+      developer.log('🔍 実際のAPI通信テストを開始', name: 'ApiConnectionTester');
+
+      // 実際のAPIキーが設定されている場合のみテスト
+      final apiKey = await AppConfig.hotpepperApiKey;
+      if (apiKey == null || apiKey.isEmpty || apiKey.startsWith('test_')) {
+        throw Exception('実際のAPIキーが必要です（テスト用キーは使用不可）');
+      }
+
+      // 最小限のリクエストでAPI接続テスト
+      final url = 'https://webservice.recruit.co.jp/hotpepper/gourmet/v1/';
+      final response = await _httpClient.get(
+        url,
+        queryParameters: {
+          'key': apiKey,
+          'format': 'json',
+          'count': '1',
+          'keyword': '中華',
+        },
+      );
+
+      final isSuccess = response.isSuccess;
+      if (!isSuccess) {
+        throw Exception('API呼び出しエラー: ${response.errorMessage}');
+      }
+
+      stopwatch.stop();
+
+      return ApiConnectionTestResult(
+        testType: 'actual_api_call',
+        isSuccessful: true,
+        duration: stopwatch.elapsed,
+        details: {
+          'response_received': true,
+          'api_accessible': true,
+        },
+      );
+    } catch (e) {
+      stopwatch.stop();
+
+      return ApiConnectionTestResult(
+        testType: 'actual_api_call',
+        isSuccessful: false,
+        errorMessage: e.toString(),
+        duration: stopwatch.elapsed,
+      );
+    }
+  }
+
+  /// 包括的なテスト実行
+  static Future<List<ApiConnectionTestResult>> runComprehensiveTest({
+    bool includeActualApiCall = false,
+  }) async {
+    developer.log('🔍 包括的API接続テストを開始', name: 'ApiConnectionTester');
+
+    final results = <ApiConnectionTestResult>[];
+
+    // 基本テスト
+    results.add(await testBasicConnectivity());
+    results.add(await testApiKeyValidation());
+    results.add(await testConfigValidation());
+
+    // 実際のAPI呼び出しテスト（オプション）
+    if (includeActualApiCall) {
+      results.add(await testActualApiCall());
+    }
+
+    final successCount = results.where((r) => r.isSuccessful).length;
+    developer.log(
+      '🔍 包括テスト完了: $successCount/${results.length} 成功',
+      name: 'ApiConnectionTester',
+    );
+
+    return results;
+  }
+
+  /// テスト結果の詳細ログ出力
+  static void logTestResults(List<ApiConnectionTestResult> results) {
+    developer.log('📊 API接続テスト結果:', name: 'ApiConnectionTester');
+
+    for (final result in results) {
+      developer.log(result.toString(), name: 'ApiConnectionTester');
+    }
+
+    final successCount = results.where((r) => r.isSuccessful).length;
+    final overall = successCount == results.length ? '✅ 全テスト成功' : '❌ 一部テスト失敗';
+
+    developer.log('🎯 総合結果: $overall ($successCount/${results.length})',
+        name: 'ApiConnectionTester');
+  }
+}

--- a/lib/core/config/api_diagnostics.dart
+++ b/lib/core/config/api_diagnostics.dart
@@ -1,0 +1,184 @@
+import 'dart:developer' as developer;
+import 'package:chinese_food_app/core/config/app_config.dart';
+import 'package:chinese_food_app/core/config/security_config.dart';
+
+/// API設定の診断情報
+class ApiDiagnosticsResult {
+  final bool isConfigValid;
+  final String hotpepperApiKeyStatus;
+  final String initializationStatus;
+  final String securityMode;
+  final String environment;
+  final DateTime timestamp;
+  final List<String> issues;
+  final List<String> suggestions;
+
+  const ApiDiagnosticsResult({
+    required this.isConfigValid,
+    required this.hotpepperApiKeyStatus,
+    required this.initializationStatus,
+    required this.securityMode,
+    required this.environment,
+    required this.timestamp,
+    required this.issues,
+    required this.suggestions,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'isConfigValid': isConfigValid,
+      'hotpepperApiKeyStatus': hotpepperApiKeyStatus,
+      'initializationStatus': initializationStatus,
+      'securityMode': securityMode,
+      'environment': environment,
+      'timestamp': timestamp.toIso8601String(),
+      'issues': issues,
+      'suggestions': suggestions,
+    };
+  }
+
+  @override
+  String toString() {
+    final buffer = StringBuffer();
+    buffer.writeln('🔍 API設定診断結果');
+    buffer.writeln('時刻: ${timestamp.toIso8601String()}');
+    buffer.writeln('環境: $environment');
+    buffer.writeln('設定状態: ${isConfigValid ? "✅ 正常" : "❌ 問題あり"}');
+    buffer.writeln('APIキー: $hotpepperApiKeyStatus');
+    buffer.writeln('初期化: $initializationStatus');
+    buffer.writeln('セキュリティ: $securityMode');
+
+    if (issues.isNotEmpty) {
+      buffer.writeln('\n❌ 問題:');
+      for (final issue in issues) {
+        buffer.writeln('  • $issue');
+      }
+    }
+
+    if (suggestions.isNotEmpty) {
+      buffer.writeln('\n💡 推奨対応:');
+      for (final suggestion in suggestions) {
+        buffer.writeln('  • $suggestion');
+      }
+    }
+
+    return buffer.toString();
+  }
+}
+
+/// API設定の診断ユーティリティ
+class ApiDiagnostics {
+  /// 包括的なAPI設定診断を実行
+  static Future<ApiDiagnosticsResult> getComprehensiveDiagnostics() async {
+    developer.log('🔍 API設定診断を開始', name: 'ApiDiagnostics');
+
+    final timestamp = DateTime.now();
+    final issues = <String>[];
+    final suggestions = <String>[];
+
+    // 初期化状態チェック
+    final initializationStatus = _checkInitializationStatus();
+    if (initializationStatus != 'initialized') {
+      issues.add('AppConfigが適切に初期化されていません');
+      suggestions.add('main()でAppConfig.initialize()を呼び出してください');
+    }
+
+    // APIキー状態チェック
+    final hotpepperApiKeyStatus = await _checkHotpepperApiKeyStatus();
+    if (hotpepperApiKeyStatus == 'missing') {
+      issues.add('HotPepper APIキーが設定されていません');
+      suggestions.add('.envファイルにHOTPEPPER_API_KEY=your_key_here を設定してください');
+    }
+
+    // セキュリティ設定チェック
+    final securityMode = _getSecurityMode();
+    if (securityMode == 'secure' && hotpepperApiKeyStatus == 'available') {
+      issues.add('セキュアモードでAPIキーが設定されています');
+      suggestions.add('セキュアモードではプロキシサーバー経由を使用してください');
+    }
+
+    // 環境情報
+    final environment = _getEnvironmentInfo();
+
+    // 基本的な推奨事項を追加
+    if (suggestions.isEmpty && issues.isEmpty) {
+      suggestions.add('設定は正常です。定期的な診断実行を推奨します');
+    }
+
+    final isConfigValid = issues.isEmpty;
+
+    final result = ApiDiagnosticsResult(
+      isConfigValid: isConfigValid,
+      hotpepperApiKeyStatus: hotpepperApiKeyStatus,
+      initializationStatus: initializationStatus,
+      securityMode: securityMode,
+      environment: environment,
+      timestamp: timestamp,
+      issues: issues,
+      suggestions: suggestions,
+    );
+
+    developer.log('🔍 診断完了: ${isConfigValid ? "正常" : "問題あり"}',
+        name: 'ApiDiagnostics');
+
+    return result;
+  }
+
+  /// 初期化状態をチェック
+  static String _checkInitializationStatus() {
+    return AppConfig.isInitialized ? 'initialized' : 'not_initialized';
+  }
+
+  /// HotPepper APIキーの状態をチェック
+  static Future<String> _checkHotpepperApiKeyStatus() async {
+    try {
+      // 初期化されていない場合は初期化を試行
+      if (!AppConfig.isInitialized) {
+        await AppConfig.initialize();
+      }
+
+      final apiKey = await AppConfig.hotpepperApiKey;
+      if (apiKey == null || apiKey.isEmpty) {
+        return 'missing';
+      }
+
+      // 最低限の妥当性チェック（長さなど）
+      if (apiKey.length < 8) {
+        return 'invalid';
+      }
+
+      return 'available';
+    } catch (e) {
+      developer.log('APIキー状態チェックエラー: $e', name: 'ApiDiagnostics');
+      return 'error';
+    }
+  }
+
+  /// セキュリティモードを取得
+  static String _getSecurityMode() {
+    if (SecurityConfig.isSecureMode) {
+      return 'secure';
+    } else if (SecurityConfig.isProxyMode) {
+      return 'proxy';
+    } else {
+      return 'legacy';
+    }
+  }
+
+  /// 環境情報を取得
+  static String _getEnvironmentInfo() {
+    if (AppConfig.isProduction) {
+      return 'production';
+    } else if (AppConfig.isDevelopment) {
+      return 'development';
+    } else {
+      return 'unknown';
+    }
+  }
+
+  /// 簡易診断（ログ出力付き）
+  static Future<void> logDiagnostics() async {
+    final diagnostics = await getComprehensiveDiagnostics();
+    developer.log(diagnostics.toString(), name: 'ApiDiagnostics');
+  }
+}

--- a/lib/data/datasources/hotpepper_api_datasource.dart
+++ b/lib/data/datasources/hotpepper_api_datasource.dart
@@ -108,10 +108,9 @@ class HotpepperApiDatasourceImpl extends BaseApiService
 
   /// APIキーの取得と存在確認
   Future<String> _getApiKey() async {
+    // AppConfigの初期化を確実に実行
     if (!AppConfig.isInitialized) {
-      throw ApiException(
-        'AppConfigが初期化されていません。main()でAppConfig.initialize()を呼び出してください。',
-      );
+      await AppConfig.initialize();
     }
 
     // セキュアモードではAPIキー直接呼び出しを禁止
@@ -121,10 +120,10 @@ class HotpepperApiDatasourceImpl extends BaseApiService
       );
     }
 
-    final apiKey = AppConfig.api.hotpepperApiKey;
-    final hasValidApiKeys = await AppConfig.hasHotpepperApiKeyAsync;
+    // 非同期でAPIキーを取得
+    final apiKey = await AppConfig.hotpepperApiKey;
 
-    if (!hasValidApiKeys || apiKey.isEmpty) {
+    if (apiKey == null || apiKey.isEmpty) {
       throw ApiException(
         'HotPepper APIキーが設定されていません。HOTPEPPER_API_KEY環境変数を設定してください。',
       );

--- a/test/unit/core/config/api_connection_test.dart
+++ b/test/unit/core/config/api_connection_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/api_connection_tester.dart';
+import '../../../helpers/test_env_setup.dart';
+
+void main() {
+  group('ApiConnectionTester', () {
+    setUp(() async {
+      await TestEnvSetup.initializeTestEnvironment();
+    });
+
+    tearDown(() {
+      TestEnvSetup.cleanupTestEnvironment();
+    });
+
+    test('should test basic connectivity', () async {
+      // Arrange
+      TestEnvSetup.setTestApiKey('HOTPEPPER_API_KEY', 'valid_test_key');
+
+      // Act
+      final result = await ApiConnectionTester.testBasicConnectivity();
+
+      // Assert
+      expect(result.isSuccessful, isTrue);
+      expect(result.testType, equals('basic_connectivity'));
+      expect(result.duration, isNotNull);
+    });
+
+    test('should detect API key issues', () async {
+      // Arrange
+      TestEnvSetup.clearTestApiKey('HOTPEPPER_API_KEY');
+
+      // Act
+      final result = await ApiConnectionTester.testApiKeyValidation();
+
+      // Assert
+      expect(result.isSuccessful, isFalse);
+      expect(result.errorMessage, contains('APIキー'));
+    });
+
+    test('should provide comprehensive connection test', () async {
+      // Arrange
+      TestEnvSetup.setTestApiKey('HOTPEPPER_API_KEY', 'test_key_123');
+
+      // Act
+      final results = await ApiConnectionTester.runComprehensiveTest();
+
+      // Assert
+      expect(results, isNotEmpty);
+      expect(results.any((r) => r.testType == 'basic_connectivity'), isTrue);
+      expect(results.any((r) => r.testType == 'api_key_validation'), isTrue);
+      expect(results.any((r) => r.testType == 'config_validation'), isTrue);
+    });
+  });
+}

--- a/test/unit/core/config/api_diagnostics_test.dart
+++ b/test/unit/core/config/api_diagnostics_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chinese_food_app/core/config/api_diagnostics.dart';
+import 'package:chinese_food_app/core/config/app_config.dart';
+import '../../../helpers/test_env_setup.dart';
+
+void main() {
+  group('ApiDiagnostics', () {
+    setUp(() async {
+      await TestEnvSetup.initializeTestEnvironment();
+    });
+
+    tearDown(() {
+      TestEnvSetup.cleanupTestEnvironment();
+    });
+
+    test('should provide comprehensive API configuration status', () async {
+      // Arrange
+      TestEnvSetup.setTestApiKey('HOTPEPPER_API_KEY', 'test_key_123');
+
+      // Act
+      final diagnostics = await ApiDiagnostics.getComprehensiveDiagnostics();
+
+      // Assert
+      expect(diagnostics.isConfigValid, isTrue);
+      expect(diagnostics.hotpepperApiKeyStatus, equals('available'));
+      expect(diagnostics.initializationStatus, equals('initialized'));
+      expect(diagnostics.securityMode, equals('legacy'));
+    });
+
+    test('should detect missing API key', () async {
+      // Arrange
+      TestEnvSetup.clearTestApiKey('HOTPEPPER_API_KEY');
+
+      // Act
+      final diagnostics = await ApiDiagnostics.getComprehensiveDiagnostics();
+
+      // Assert
+      expect(diagnostics.isConfigValid, isFalse);
+      expect(diagnostics.hotpepperApiKeyStatus, equals('missing'));
+      expect(diagnostics.issues, contains('HotPepper APIキーが設定されていません'));
+    });
+
+    test('should provide detailed configuration info', () async {
+      // Arrange
+      TestEnvSetup.setTestApiKey('HOTPEPPER_API_KEY', 'valid_key');
+
+      // Act
+      final diagnostics = await ApiDiagnostics.getComprehensiveDiagnostics();
+
+      // Assert
+      expect(diagnostics.environment, isNotEmpty);
+      expect(diagnostics.timestamp, isNotNull);
+      expect(diagnostics.suggestions, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 概要
Issue #185で報告されたバックエンドAPI接続問題を調査し、根本原因を特定・修正しました。

## 🔍 特定した問題
1. **APIキー取得の非同期/同期不整合**: `HotpepperApiDatasourceImpl._getApiKey()`で同期版APIキー取得を使用していた
2. **初期化タイミング問題**: AppConfigの初期化が適切に実行されていない場合があった
3. **エラーメッセージの不明確さ**: 具体的な原因が分からないエラーメッセージ

## 🛠️ 修正内容

### 1. APIキー取得の非同期化
- `AppConfig.api.hotpepperApiKey`（同期版）から`AppConfig.hotpepperApiKey`（非同期版）に変更
- AppConfig初期化の自動実行機能を追加

### 2. 診断機能の新規実装
- **ApiDiagnostics**: 包括的な設定診断機能
- **ApiConnectionTester**: API接続テスト機能
- 詳細なエラーメッセージと推奨対応案を提供

## 📋 テスト計画
- [x] Issue #185専用のテストケース追加
- [x] API診断機能の包括的テスト
- [x] API接続テスト機能のテスト
- [x] 既存テストのリグレッション確認

## 🎯 解決される問題
- バックエンドAPI接続エラーの根本原因解決
- 設定問題の早期発見・診断機能
- 開発者フレンドリーなエラーメッセージ

## 🔗 関連Issue
Closes #185

🤖 Generated with [Claude Code](https://claude.ai/code)