### PR TITLE
refactor: コメントアウトされた未使用コードの削除 (#187)

### DIFF
--- a/lib/core/services/crash_monitoring_service.dart
+++ b/lib/core/services/crash_monitoring_service.dart
@@ -106,13 +106,6 @@ class CrashMonitoringService {
       }
 
       // ログ記録（本番環境ではCrashlyticsに送信）
-      // 将来的にはlogRecordをCrashlyticsに送信
-      // final logRecord = LogRecord(
-      //   message: message,
-      //   level: level,
-      //   metadata: metadata ?? {},
-      //   timestamp: DateTime.now(),
-      // );
 
       // テスト環境では常に失敗を返す
       return Failure(BaseException('テスト環境ではログメッセージを送信できません'));


### PR DESCRIPTION
## 概要
コードベース内のコメントアウトされた未使用コードを削除し、コードの可読性と保守性を向上させました。

## 変更内容
### 削除したコメントアウトコード
- **`lib/core/services/crash_monitoring_service.dart` (行110-115)**
  - LogRecordのコメントアウトされた使用例を削除
  - LogRecordクラスは既に定義済み（行280-292）のため、このコメントアウトコードは不要

### 保持したコード（Issue対応予定）
以下のコメントアウトコードは、特定のIssueで対応予定のため保持しています：

- **Issue #113対応予定**
  - `lib/core/di/app_di_container_old.dart` (行260-265): 永続化データベース実装
  - `lib/core/utils/database_error_handler.dart` (行1, 100-111): 型安全なエラーハンドリング

- **Issue #155対応予定**
  - `lib/presentation/providers/store_business_logic.dart` (行8-10): 位置情報機能

- **将来の拡張用テンプレート**
  - `lib/core/di/di_container.dart` (行60-71): DIコンテナ拡張例（ドキュメントとして有用）

## テスト結果
```bash
flutter test test/unit/core/services/crash_monitoring_service_test.dart
```
- 全10件のテスト通過 ✅
- 今回の変更による機能への影響なし

## Closes
Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)