### PR TITLE
店舗詳細ページに地図を常時表示 #190

### DIFF
--- a/lib/presentation/pages/store_detail/store_detail_page.dart
+++ b/lib/presentation/pages/store_detail/store_detail_page.dart
@@ -38,7 +38,17 @@ class StoreDetailPage extends StatelessWidget {
               onStatusChanged: (newStatus) =>
                   _updateStoreStatus(context, newStatus),
               onAddVisitRecord: () => _navigateToVisitRecordForm(context),
-              onShowMap: () => _showMap(context),
+            ),
+            // 地図を常時表示
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: SizedBox(
+                height: 250,
+                child: WebViewMapWidget(
+                  store: store,
+                  useOpenStreetMap: true,
+                ),
+              ),
             ),
           ],
         ),
@@ -72,37 +82,5 @@ class StoreDetailPage extends StatelessWidget {
 
   void _navigateToVisitRecordForm(BuildContext context) {
     context.pushNamed('visit-record-form', extra: store);
-  }
-
-  void _showMap(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => Dialog(
-        child: SizedBox(
-          height: 400.0,
-          width: double.maxFinite,
-          child: Column(
-            children: [
-              AppBar(
-                title: Text(store.name),
-                automaticallyImplyLeading: false,
-                actions: [
-                  IconButton(
-                    icon: const Icon(Icons.close),
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                ],
-              ),
-              Expanded(
-                child: WebViewMapWidget(
-                  store: store,
-                  useOpenStreetMap: true,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/lib/presentation/pages/store_detail/widgets/store_action_widget.dart
+++ b/lib/presentation/pages/store_detail/widgets/store_action_widget.dart
@@ -7,13 +7,11 @@ class StoreActionWidget extends StatelessWidget {
     required this.store,
     required this.onStatusChanged,
     required this.onAddVisitRecord,
-    required this.onShowMap,
   });
 
   final Store store;
   final Function(StoreStatus) onStatusChanged;
   final VoidCallback onAddVisitRecord;
-  final VoidCallback onShowMap;
 
   @override
   Widget build(BuildContext context) {
@@ -152,40 +150,20 @@ class StoreActionWidget extends StatelessWidget {
       BuildContext context, ThemeData theme, ColorScheme colorScheme) {
     return Padding(
       padding: const EdgeInsets.all(16.0),
-      child: Column(
-        children: [
-          SizedBox(
-            width: double.infinity,
-            child: Semantics(
-              label: '${store.name}の訪問記録を追加',
-              button: true,
-              child: FilledButton.icon(
-                onPressed: onAddVisitRecord,
-                icon: const Icon(Icons.add),
-                label: const Text('訪問記録を追加'),
-                style: FilledButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                ),
-              ),
+      child: SizedBox(
+        width: double.infinity,
+        child: Semantics(
+          label: '${store.name}の訪問記録を追加',
+          button: true,
+          child: FilledButton.icon(
+            onPressed: onAddVisitRecord,
+            icon: const Icon(Icons.add),
+            label: const Text('訪問記録を追加'),
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
             ),
           ),
-          const SizedBox(height: 8),
-          SizedBox(
-            width: double.infinity,
-            child: Semantics(
-              label: '${store.name}の場所を地図で表示',
-              button: true,
-              child: OutlinedButton.icon(
-                onPressed: onShowMap,
-                icon: const Icon(Icons.map),
-                label: const Text('地図で表示'),
-                style: OutlinedButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                ),
-              ),
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/test/widget/pages/store_detail/store_detail_page_test.dart
+++ b/test/widget/pages/store_detail/store_detail_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:chinese_food_app/domain/entities/store.dart';
 import 'package:chinese_food_app/presentation/pages/store_detail/store_detail_page.dart';
+import 'package:chinese_food_app/presentation/widgets/webview_map_widget.dart';
 
 void main() {
   group('StoreDetailPage Widget Tests', () {
@@ -99,7 +100,6 @@ void main() {
 
       // アクションボタンが存在することを確認
       expect(find.text('訪問記録を追加'), findsOneWidget);
-      expect(find.text('地図で表示'), findsOneWidget);
     });
 
     testWidgets('should show current status as selected', (tester) async {
@@ -129,8 +129,7 @@ void main() {
       expect(find.text('行った'), findsWidgets);
     });
 
-    testWidgets('should show map dialog when map button is tapped',
-        (tester) async {
+    testWidgets('should display WebViewMapWidget in the page', (tester) async {
       // Act
       await tester.pumpWidget(
         MaterialApp(
@@ -138,28 +137,11 @@ void main() {
         ),
       );
 
-      // Scroll to make the map button visible
-      await tester.scrollUntilVisible(
-        find.text('地図で表示'),
-        500.0,
-        scrollable: find.byType(Scrollable).first,
-      );
-
-      // Find and tap the map button
-      final mapButton = find.text('地図で表示');
-      expect(mapButton, findsOneWidget);
-
-      await tester.tap(mapButton);
-      await tester.pumpAndSettle();
-
-      // Assert - Map dialog should be displayed
-      expect(find.byType(Dialog), findsOneWidget);
-      expect(find.text('テスト中華料理店'), findsWidgets); // Store name in dialog title
-      expect(find.byIcon(Icons.close), findsOneWidget); // Close button
+      // Assert - WebViewMapWidget should be present in the page
+      expect(find.byType(WebViewMapWidget), findsOneWidget);
     });
 
-    testWidgets('should close map dialog when close button is tapped',
-        (tester) async {
+    testWidgets('should not display "地図で表示" button', (tester) async {
       // Act
       await tester.pumpWidget(
         MaterialApp(
@@ -167,22 +149,8 @@ void main() {
         ),
       );
 
-      // Scroll to make the map button visible and tap it
-      await tester.scrollUntilVisible(
-        find.text('地図で表示'),
-        500.0,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.tap(find.text('地図で表示'));
-      await tester.pumpAndSettle();
-      expect(find.byType(Dialog), findsOneWidget);
-
-      // Close dialog
-      await tester.tap(find.byIcon(Icons.close));
-      await tester.pumpAndSettle();
-
-      // Assert - Dialog should be closed
-      expect(find.byType(Dialog), findsNothing);
+      // Assert - "地図で表示" button should not be present
+      expect(find.text('地図で表示'), findsNothing);
     });
   });
 }

--- a/test/widget/pages/store_detail/widgets/store_action_widget_test.dart
+++ b/test/widget/pages/store_detail/widgets/store_action_widget_test.dart
@@ -13,16 +13,11 @@ class MockOnAddVisitRecord extends Mock {
   void call();
 }
 
-class MockOnShowMap extends Mock {
-  void call();
-}
-
 void main() {
   group('StoreActionWidget Tests', () {
     late Store testStore;
     late MockOnStatusChanged mockOnStatusChanged;
     late MockOnAddVisitRecord mockOnAddVisitRecord;
-    late MockOnShowMap mockOnShowMap;
 
     setUp(() {
       testStore = Store(
@@ -38,7 +33,6 @@ void main() {
 
       mockOnStatusChanged = MockOnStatusChanged();
       mockOnAddVisitRecord = MockOnAddVisitRecord();
-      mockOnShowMap = MockOnShowMap();
     });
 
     testWidgets('should display status change section', (tester) async {
@@ -50,7 +44,6 @@ void main() {
               store: testStore,
               onStatusChanged: mockOnStatusChanged.call,
               onAddVisitRecord: mockOnAddVisitRecord.call,
-              onShowMap: mockOnShowMap.call,
             ),
           ),
         ),
@@ -63,7 +56,7 @@ void main() {
       expect(find.text('興味なし'), findsOneWidget);
     });
 
-    testWidgets('should display action buttons', (tester) async {
+    testWidgets('should display visit record button', (tester) async {
       // Act
       await tester.pumpWidget(
         MaterialApp(
@@ -72,7 +65,6 @@ void main() {
               store: testStore,
               onStatusChanged: mockOnStatusChanged.call,
               onAddVisitRecord: mockOnAddVisitRecord.call,
-              onShowMap: mockOnShowMap.call,
             ),
           ),
         ),
@@ -80,9 +72,26 @@ void main() {
 
       // Assert
       expect(find.text('訪問記録を追加'), findsOneWidget);
-      expect(find.text('地図で表示'), findsOneWidget);
       expect(find.byIcon(Icons.add), findsOneWidget);
-      expect(find.byIcon(Icons.map), findsOneWidget);
+    });
+
+    testWidgets('should not display map button', (tester) async {
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StoreActionWidget(
+              store: testStore,
+              onStatusChanged: mockOnStatusChanged.call,
+              onAddVisitRecord: mockOnAddVisitRecord.call,
+            ),
+          ),
+        ),
+      );
+
+      // Assert - Map button should not be displayed
+      expect(find.text('地図で表示'), findsNothing);
+      expect(find.byIcon(Icons.map), findsNothing);
     });
 
     testWidgets('should highlight current status correctly', (tester) async {
@@ -94,7 +103,6 @@ void main() {
               store: testStore,
               onStatusChanged: mockOnStatusChanged.call,
               onAddVisitRecord: mockOnAddVisitRecord.call,
-              onShowMap: mockOnShowMap.call,
             ),
           ),
         ),
@@ -122,7 +130,6 @@ void main() {
               store: testStore,
               onStatusChanged: mockOnStatusChanged.call,
               onAddVisitRecord: mockOnAddVisitRecord.call,
-              onShowMap: mockOnShowMap.call,
             ),
           ),
         ),
@@ -147,7 +154,6 @@ void main() {
               store: testStore,
               onStatusChanged: mockOnStatusChanged.call,
               onAddVisitRecord: mockOnAddVisitRecord.call,
-              onShowMap: mockOnShowMap.call,
             ),
           ),
         ),
@@ -159,30 +165,6 @@ void main() {
 
       // Assert
       verify(mockOnAddVisitRecord.call()).called(1);
-    });
-
-    testWidgets('should call onShowMap when map button is tapped',
-        (tester) async {
-      // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: StoreActionWidget(
-              store: testStore,
-              onStatusChanged: mockOnStatusChanged.call,
-              onAddVisitRecord: mockOnAddVisitRecord.call,
-              onShowMap: mockOnShowMap.call,
-            ),
-          ),
-        ),
-      );
-
-      // Tap on map button
-      await tester.tap(find.text('地図で表示'));
-      await tester.pumpAndSettle();
-
-      // Assert
-      verify(mockOnShowMap.call()).called(1);
     });
   });
 }


### PR DESCRIPTION
## 概要

Issue #190 の対応として、店舗詳細ページで地図を常時表示するように変更しました。

## 変更内容

### 実装の変更
- **StoreActionWidget**: 「地図で表示」ボタンとその関連機能を削除
- **StoreDetailPage**: 地図を常時表示する`WebViewMapWidget`を追加（高さ250px）
- **ダイアログ削除**: `_showMap`メソッドとダイアログ表示機能を削除

### テストの更新
- `store_action_widget_test.dart`: 地図ボタン関連のテストを削除、地図ボタンが表示されないことをテスト
- `store_detail_page_test.dart`: 地図ダイアログ関連のテストを削除、地図が常時表示されることをテスト

## 影響

### ユーザー体験の改善
✅ 店舗詳細を見ながら地図を確認可能  
✅ ボタンタップ不要で地図が表示される  
✅ スクロールだけで地図まで移動可能

### コードの改善
✅ UIがシンプルになり操作性が向上  
✅ 不要なダイアログコードを削除（約100行削減）  
✅ テストコードも簡素化

## テスト結果

店舗詳細ページ関連のテストは全て通過:
```
✓ 30 tests passed
```

## スクリーンショット

（実装完了後、必要に応じて追加）

## 確認事項

- [x] dart format実行済み
- [x] flutter analyze実行済み（エラーなし）
- [x] 関連テスト全件通過
- [x] 不要なコード削除済み
- [x] コミットメッセージ適切

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)