### PR TITLE
fix: Provider/DI関連のウィジェットテスト失敗を修正 (Issue #211)

### DIFF
--- a/test/unit/core/routing/app_router_test.dart
+++ b/test/unit/core/routing/app_router_test.dart
@@ -30,6 +30,7 @@ void main() {
     Widget createApp() {
       return MultiProvider(
         providers: [
+          Provider<DIContainerInterface>.value(value: container),
           ChangeNotifierProvider.value(value: container.getStoreProvider()),
           Provider<LocationService>.value(
               value: container.getLocationService()),

--- a/test/widget/pages/shell/shell_page_test.dart
+++ b/test/widget/pages/shell/shell_page_test.dart
@@ -27,6 +27,7 @@ void main() {
     Widget createApp() {
       return MultiProvider(
         providers: [
+          Provider<DIContainerInterface>.value(value: container),
           ChangeNotifierProvider.value(value: container.getStoreProvider()),
           Provider<LocationService>.value(
               value: container.getLocationService()),


### PR DESCRIPTION
## 概要
ウィジェットテストで`DIContainerInterface`のProviderが不足していたため、3件のテストが失敗していた問題を修正しました。

## 問題の原因
`MyMenuPage`と`StoreDetailPage`が`Provider.of<DIContainerInterface>(context, listen: false)`を使用してDIコンテナを取得していましたが、テストでは以下のProviderのみを提供していました：
- `ChangeNotifierProvider<StoreProvider>`
- `Provider<LocationService>`

`Provider<DIContainerInterface>`が不足していたため、`ProviderNotFoundException`が発生していました。

## 修正内容
以下の2つのテストファイルの`createApp()`関数に`Provider<DIContainerInterface>.value(value: container)`を追加しました：

### 1. [test/unit/core/routing/app_router_test.dart](test/unit/core/routing/app_router_test.dart)
```dart
Widget createApp() {
  return MultiProvider(
    providers: [
      Provider<DIContainerInterface>.value(value: container),  // ✅ 追加
      ChangeNotifierProvider.value(value: container.getStoreProvider()),
      Provider<LocationService>.value(value: container.getLocationService()),
    ],
    child: MaterialApp.router(
      routerConfig: router,
    ),
  );
}
```

### 2. [test/widget/pages/shell/shell_page_test.dart](test/widget/pages/shell/shell_page_test.dart)
同様に`Provider<DIContainerInterface>`を追加

## 修正されたテスト（3件）
✅ `app_router_test.dart`: `/my-menu ルートでMyMenuPageが表示される`
✅ `app_router_test.dart`: `正常なStoreオブジェクトが渡された場合、StoreDetailPageが表示される`
✅ `shell_page_test.dart`: `マイメニュータブをタップするとマイメニュー画面に遷移する`

## テスト結果
```bash
# 修正対象のテストファイル
$ flutter test test/unit/core/routing/app_router_test.dart test/widget/pages/shell/shell_page_test.dart
00:00 +19: All tests passed! ✅
```

## チェックリスト
- [x] テストが全て成功することを確認
- [x] `dart format .` を実行
- [x] コミットメッセージに適切な説明を記載
- [x] Issue #211 の要件を満たしている

## 関連Issue
Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)