### PR TITLE
fix: Linter警告の解消: avoid_types_as_parameter_names

### DIFF
--- a/lib/domain/usecases/base_usecase.dart
+++ b/lib/domain/usecases/base_usecase.dart
@@ -8,7 +8,7 @@ import '../../core/types/result.dart';
 ///
 /// The base class provides a consistent interface for all Use Cases:
 /// - Input parameters of type [Params]
-/// - Output wrapped in a [Result<Type>] for unified error handling
+/// - Output wrapped in a [Result<T>] for unified error handling
 /// - Async execution with [Future] support
 ///
 /// Example usage:
@@ -34,20 +34,20 @@ import '../../core/types/result.dart';
 ///     handleError(result.exception);
 /// }
 /// ```
-abstract class BaseUseCase<Params, Type> {
+abstract class BaseUseCase<Params, T> {
   /// Executes the use case with the given parameters
   ///
   /// [params] - Input parameters for the use case
-  /// Returns a [Future<Result<Type>>] containing either:
-  /// - [Success<Type>] with the operation result
-  /// - [Failure<Type>] with an exception describing the error
+  /// Returns a [Future<Result<T>>] containing either:
+  /// - [Success<T>] with the operation result
+  /// - [Failure<T>] with an exception describing the error
   ///
   /// Implementation requirements:
   /// - Should handle all exceptions and wrap them in [Failure]
   /// - Should validate input parameters if necessary
   /// - Should be stateless and side-effect free when possible
   /// - Should delegate complex logic to repositories and services
-  Future<Result<Type>> call(Params params);
+  Future<Result<T>> call(Params params);
 }
 
 /// Parameter class for Use Cases that don't require input parameters


### PR DESCRIPTION
## Summary
- BaseUseCaseクラスの型パラメータ名`Type`を`T`に変更
- `flutter analyze`の`avoid_types_as_parameter_names`警告を解消
- 既存の継承クラスは具体的な型を使用しているため影響なし

## 変更内容
型パラメータ名`Type`がDartの予約語`Type`と衝突していたため、Dart慣例に従い`T`に変更しました。

## Test plan
- [x] `flutter analyze`で警告ゼロ確認
- [x] `flutter test`で全テスト成功（1304 passed, 18 skipped）

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)